### PR TITLE
Separate core from cli

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -11,6 +11,7 @@
     "global-require": "off",
     "no-multi-assign": "off",
     "import/no-dynamic-require": "off",
-    "no-return-assign": "off"
+    "no-return-assign": "off",
+    "no-unused-expressions": "off"
   }
 }

--- a/packages/kodiak-core/src/kodiak.js
+++ b/packages/kodiak-core/src/kodiak.js
@@ -2,7 +2,9 @@ const Runner = require('./runner');
 
 function kodiak(context, plugins) {
   const runner = new Runner(context);
+
   runner.apply(...plugins);
+
   return runner;
 }
 

--- a/packages/kodiak-core/src/runner.js
+++ b/packages/kodiak-core/src/runner.js
@@ -7,12 +7,14 @@ const WORKER_BIN = require.resolve('./worker');
 module.exports = class Runner extends Tapable {
   constructor(context) {
     super();
+
     this.context = context;
     this.workers = workerFarm(WORKER_BIN);
   }
 
   run(tasks) {
     this.applyPlugins('start', tasks);
+
     const runTasks = (promise, tasksArray) =>
       promise.then((previous) => {
         const promises = tasksArray
@@ -25,8 +27,10 @@ module.exports = class Runner extends Tapable {
 
     return tasks.reduce(runTasks, Promise.resolve([]))
       .then((errors) => {
-        if (errors.length) this.applyPlugins('finish-with-errors', errors);
-        else this.applyPlugins('finish-without-errors');
+        errors.length ?
+          this.applyPlugins('finish-with-errors', errors) :
+          this.applyPlugins('finish-without-errors');
+
         return errors;
       });
   }


### PR DESCRIPTION
The full flow of Kodiak is to run multiple plugins in a sequence.
I think that the core should handle the full runtime, from `runtime start` to `runtime finish`.
There is one context for the whole run phase.

If we want to write plugins that know about the whole run phase we have to put that logic in the core.

@ronami wdyt ?