### PR TITLE
enable task resolution from context that supports shorter task names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ yarn-error.log*
 yarn.lock
 package-lock.json
 lerna-debug.log
+!packages/kodiak/test/fixtures/node_modules

--- a/packages/kodiak-cli/bin/kodiak.js
+++ b/packages/kodiak-cli/bin/kodiak.js
@@ -6,6 +6,7 @@ const cosmiconfig = require('cosmiconfig');
 const kodiak = require('kodiak');
 const loudRejection = require('loud-rejection');
 
+const context = process.cwd();
 // Install the unhandledRejection listeners
 loudRejection();
 const explorer = cosmiconfig('kodiak');
@@ -27,15 +28,21 @@ const { argv } = yargs
 
 const [cmd] = argv._;
 
-explorer.load(process.cwd())
+explorer.load(context)
   .then(({ config }) => {
-    const context = resolveFrom(process.cwd(), config.preset);
-    const preset = require(context);
+    const presetPath = resolveFrom(context, config.preset);
+    const preset = require(presetPath);
     const { commands, plugins } = preset(argv, config);
 
-    const runner = kodiak(plugins);
+    const options = {
+      title: cmd,
+      context,
+      plugins,
+    };
 
-    runner.run(commands[cmd], cmd)
+    const runner = kodiak(options);
+
+    runner.run(commands[cmd])
       .then((errors) => {
         if (errors.length) {
           errors.filter(Boolean).map(console.error);

--- a/packages/kodiak-preset-example/src/index.js
+++ b/packages/kodiak-preset-example/src/index.js
@@ -6,11 +6,11 @@ module.exports = ({ files, watch }) => {
   const commands = {
     test: [
       [
-        { module: require.resolve('kodiak-task-mocha'), options: { files, watch } },
-        { module: require.resolve('kodiak-task-webpack'), options: { plugins: [require.resolve('kodiak-webpack-plugin-example')] } },
+        { name: require.resolve('kodiak-task-mocha'), options: { files, watch } },
+        { name: require.resolve('kodiak-task-webpack'), options: { plugins: [require.resolve('kodiak-webpack-plugin-example')] } },
       ],
       [
-        { module: require.resolve('kodiak-task-server') }
+        { name: require.resolve('kodiak-task-server') }
       ]
     ]
   };

--- a/packages/kodiak/package.json
+++ b/packages/kodiak/package.json
@@ -6,6 +6,7 @@
   "license": "MIT",
   "dependencies": {
     "rxjs": "^5.4.3",
-    "tapable": "^0.2.8"
+    "tapable": "^0.2.8",
+    "resolve-from": "^3.0.0"
   }
 }

--- a/packages/kodiak/src/kodiak.js
+++ b/packages/kodiak/src/kodiak.js
@@ -1,7 +1,7 @@
 const Runner = require('./runner');
 
-function kodiak(plugins = []) {
-  const runner = new Runner();
+function kodiak({ plugins = [], context = __dirname, title } = {}) {
+  const runner = new Runner({ context, title });
 
   runner.apply(...plugins);
 

--- a/packages/kodiak/src/utils.js
+++ b/packages/kodiak/src/utils.js
@@ -1,1 +1,19 @@
+const path = require('path');
+const resolveFrom = require('resolve-from');
+
+const KODIAK_PLUGIN_PREFIX_REGEX = /^(?!@|[^/]+\/|kodiak-task-)/;
+
 module.exports.flatten = list => list.reduce((sub, elm) => sub.concat(elm), []);
+
+const standardizeTaskName = module.exports.standardizeTaskName = (name) => {
+  // example -> kodiak-task-example
+  return name.replace(KODIAK_PLUGIN_PREFIX_REGEX, 'kodiak-task-');
+};
+
+module.exports.resolveTaskName = (taskName, runContext) => {
+  if (path.isAbsolute(taskName)) {
+    return taskName;
+  }
+
+  return resolveFrom(runContext, standardizeTaskName(taskName));
+};

--- a/packages/kodiak/test/fixtures/kodiak-task-successful.js
+++ b/packages/kodiak/test/fixtures/kodiak-task-successful.js
@@ -1,0 +1,4 @@
+module.exports = () => {
+  console.log('successful-task');
+  return Promise.resolve();
+};

--- a/packages/kodiak/test/fixtures/node_modules/kodiak-task-successful/index.js
+++ b/packages/kodiak/test/fixtures/node_modules/kodiak-task-successful/index.js
@@ -1,0 +1,4 @@
+module.exports = () => {
+  console.log('successful-task');
+  return Promise.resolve();
+};

--- a/packages/kodiak/test/utils.spec.js
+++ b/packages/kodiak/test/utils.spec.js
@@ -1,0 +1,7 @@
+const { standardizeTaskName } = require('../src/utils.js');
+
+describe('standardizeTaskName', () => {
+  it('should add "kodiak-task-" if needed', () => {
+    expect(standardizeTaskName('example')).toEqual('kodiak-task-example');
+  });
+});


### PR DESCRIPTION
for example:

```
example -> kodiak-task-example
```