### PR TITLE
add loader better run names

### DIFF
--- a/packages/haste-plugin-loader/src/index.js
+++ b/packages/haste-plugin-loader/src/index.js
@@ -1,4 +1,5 @@
 const SequenceLoader = require('./sequence-logger/sequence-loader');
+const { generateRunTitle } = require('./utils');
 
 module.exports = class LoaderPlugin {
   constructor({ oneLinerTasks = true, frameRate = 60 } = {}) {
@@ -17,7 +18,7 @@ module.exports = class LoaderPlugin {
     });
 
     runner.plugin('start-run', (runPhase) => {
-      const runTitle = runPhase.tasks.map(task => task.name).join(',');
+      const runTitle = generateRunTitle(runPhase.tasks);
       const tasksLength = runPhase.tasks.length;
       const loaderRun = loader.startRun(runTitle, tasksLength);
 

--- a/packages/haste-plugin-loader/src/utils.js
+++ b/packages/haste-plugin-loader/src/utils.js
@@ -4,3 +4,13 @@ module.exports.delta = (start) => {
 
   return [end, time];
 };
+
+module.exports.generateRunTitle = (tasks) => {
+  if (tasks[0].name === 'read' && tasks[1].name === 'write') {
+    return 'copy';
+  }
+
+  return tasks
+    .filter(t => !['read', 'write'].includes(t.name))
+    .map(task => task.name).join(',');
+};


### PR DESCRIPTION
Understand that `read` + `write` = `copy`
Removes the `read` and the `write` from tasks like `babel` or `sass` when the read and write functionality is not needed at the title.