### PR TITLE
task-emitters poc 📲, run returns an array of emitters

### DIFF
--- a/packages/haste-core/src/runner.js
+++ b/packages/haste-core/src/runner.js
@@ -58,9 +58,9 @@ module.exports = class Runner extends Tapable {
     this.applyPlugins('start-run', runPhase);
 
     return runPhase.run()
-      .then((results) => {
-        runPhase.applyPlugins('succeed-run', results);
-        return results;
+      .then((taskEmitters) => {
+        runPhase.applyPlugins('succeed-run', taskEmitters);
+        return taskEmitters;
       })
       .catch((error) => {
         runPhase.applyPlugins('failed-run', error);

--- a/packages/haste-core/src/worker-bin.js
+++ b/packages/haste-core/src/worker-bin.js
@@ -4,7 +4,12 @@ function parseError(error) {
   }, {});
 }
 
+
 process.on('message', ({ options = {}, input, id }) => {
+  const emitEvent = (eventName, value) => {
+    process.send({ type: eventName, value, id });
+  };
+
   const handleError = (error) => {
     if (error instanceof Error) {
       error = parseError(error); // eslint-disable-line no-param-reassign
@@ -14,14 +19,14 @@ process.on('message', ({ options = {}, input, id }) => {
       console.log(error.stack || error);
     }
 
-    process.send({ type: 'failure', error, id });
+    emitEvent('failure', error);
   };
 
   let promise;
 
   try {
-    promise = require(process.argv[2])(options)(input)
-      .then(result => process.send({ type: 'success', result, id }));
+    promise = require(process.argv[2])(options, emitEvent)(input)
+      .then(result => emitEvent('success', result));
   } catch (error) {
     handleError(error);
   }

--- a/packages/haste-core/src/worker.js
+++ b/packages/haste-core/src/worker.js
@@ -1,5 +1,13 @@
 const Tapable = require('tapable');
 const uuid = require('uuid/v4');
+const EventEmitter = require('events');
+
+class TaskEmitter extends EventEmitter {
+  constructor(value) {
+    super();
+    this.value = value;
+  }
+}
 
 module.exports = class extends Tapable {
   constructor({ name, modulePath, child }) {
@@ -8,13 +16,32 @@ module.exports = class extends Tapable {
     this.name = name;
     this.modulePath = modulePath;
     this.child = child;
+    this.taskEmitters = {};
 
     this.callbacks = {};
 
-    this.child.on('message', ({ type, result, error, id }) => {
-      return type === 'failure' ?
-        this.callbacks[id].reject(error) :
-        this.callbacks[id].resolve(result);
+    this.child.on('message', ({ type, value, id }) => {
+      switch (type) {
+        case 'success': {
+          if (this.taskEmitters[id]) {
+            return this.taskEmitters[id].value = value;
+          }
+
+          this.taskEmitters[id] = new TaskEmitter(value);
+          return this.callbacks[id].resolve(this.taskEmitters[id]);
+        }
+
+        case 'failure': {
+          if (this.taskEmitters[id]) {
+            return this.taskEmitters[id].value = value;
+          }
+
+          return this.callbacks[id].reject(value);
+        }
+
+        default:
+          return this.taskEmitters[id] && this.taskEmitters[id].emit(type, value);
+      }
     });
   }
 

--- a/packages/haste-core/test/haste.spec.js
+++ b/packages/haste-core/test/haste.spec.js
@@ -51,7 +51,7 @@ describe('haste', () => {
 
         const result = await api.run({ task: successful });
 
-        expect(result).toEqual(undefined);
+        expect(result.value).toEqual(undefined);
         expect(stdout).toMatch('successful-task\n');
       });
     });
@@ -103,7 +103,7 @@ describe('haste', () => {
           { task: successful }
         );
 
-        expect(result).toEqual(undefined);
+        expect(result.value).toEqual(undefined);
         expect(stdout).toMatch(['successful-task\n', 'successful-task\n'].join(''));
       });
     });
@@ -235,7 +235,7 @@ describe('haste', () => {
 
         const result = await api.run({ task: returnedValue });
 
-        expect(result).toEqual('some-value');
+        expect(result[0].value).toEqual('some-value');
         expect(stdout).toMatch('returned-value-task\n');
       });
     });
@@ -253,7 +253,8 @@ describe('haste', () => {
           { task: loggingValue }
         );
 
-        expect(result).toEqual('some-other-value');
+
+        expect(result[1].value).toEqual('some-other-value');
         expect(stdout).toEqual(['returned-value-task\n', 'logging-value-task\n', 'some-value\n'].join(''));
       });
     });
@@ -268,7 +269,7 @@ describe('haste', () => {
 
         const result = await api.run({ task: loggingOptions, options: { value: 'some-value' } });
 
-        expect(result).toEqual('some-value');
+        expect(result[0].value).toEqual('some-value');
         expect(stdout).toEqual(['logging-options-task\n', '{ value: \'some-value\' }\n'].join(''));
       });
     });
@@ -281,7 +282,7 @@ describe('haste', () => {
         });
 
         const result = await api.run({ task: successful, metadata: { title: 'awesome-task' } });
-        expect(result).toEqual(undefined);
+        expect(result.value).toEqual(undefined);
 
         const firstRunPhase = runPhase.mock.calls[0][0];
         expect(firstRunPhase.tasks[0].metadata).toEqual({ title: 'awesome-task' });
@@ -320,7 +321,7 @@ describe('haste', () => {
 
         const result = await api.run({ task: './successful-task' });
 
-        expect(result).toEqual(undefined);
+        expect(result.value).toEqual(undefined);
         expect(stdout).toMatch('successful-task\n');
       });
     });
@@ -335,7 +336,7 @@ describe('haste', () => {
 
         const result = await api.run({ task: 'haste-task-successful' });
 
-        expect(result).toEqual(undefined);
+        expect(result.value).toEqual(undefined);
         expect(stdout).toMatch('successful-task\n');
       });
     });
@@ -350,7 +351,7 @@ describe('haste', () => {
 
         const result = await api.run({ task: 'successful' });
 
-        expect(result).toEqual(undefined);
+        expect(result.value).toEqual(undefined);
         expect(stdout).toEqual('successful-task\n');
       });
     });


### PR DESCRIPTION
Every task could use the emit function to send events through the taskEmitter.

```js
const typescriptTask = await run(typescript());

typescriptTask.on('output', () => { // listen to output changes from the typescript task
  restartServer();
});
```

```js
module.exports = ({ watch } = {}, emit) =>  async () => {
    const tscBin = require.resolve('typescript/bin/tsc');
    const tscWroker = spawn(tscBin, watch ? ['--watch'] : []);

    return new Promise((resolve, reject) => {
      tscWroker.stdout.on('data', output => emit('output', output)) // send an output event to the task listeners
      );

      tscWroker.on('exit', code => code === 0 ? resolve() : reject());
    });
  };
```