### PR TITLE
fix flaky test

### DIFF
--- a/packages/haste-core/test/haste.spec.js
+++ b/packages/haste-core/test/haste.spec.js
@@ -146,7 +146,7 @@ describe('haste', () => {
           await runner.run({ task: hardError });
         } catch (error) {
           expect(error.message).toEqual('some-error');
-          expect(stdout.mock.calls).toContainEqual(['hard-error-task\n']);
+          expect(stdout.mock.calls[0]).toEqual(expect.stringMatching('hard-error-task\n'));
         }
       });
     });


### PR DESCRIPTION
The `hard-error-task` was flaky on [that ci run](https://travis-ci.org/wix/haste/builds/289408492#L541). 

__edit:__ which later restarted that build so now you can't really see the failure 😓...

I reckon that the `toContainEqual` method is not suitable when the console.log and the error output are in the same place.

I changed it to only want to test the output of the first call.