### PR TITLE
task can now add a metadata object, which plugins can use later on

### DIFF
--- a/packages/haste-core/src/haste.js
+++ b/packages/haste-core/src/haste.js
@@ -10,10 +10,11 @@ const watch = (pattern, callback) => {
 };
 
 const tasks = new Proxy({}, {
-  get: (target, prop) => (options) => {
+  get: (target, prop) => (options, metadata) => {
     return {
       task: isPath(prop) ? prop : camelCaseToDash(prop),
       options,
+      metadata,
     };
   }
 });

--- a/packages/haste-core/src/haste.js
+++ b/packages/haste-core/src/haste.js
@@ -1,6 +1,6 @@
 const chokidar = require('chokidar');
 const Runner = require('./runner');
-const { camelCaseToDash } = require('./utils');
+const { camelCaseToDash, isPath } = require('./utils');
 
 const watch = (pattern, callback) => {
   const watcher = chokidar.watch(pattern, { ignoreInitial: true, cwd: process.cwd() })
@@ -12,7 +12,7 @@ const watch = (pattern, callback) => {
 const tasks = new Proxy({}, {
   get: (target, prop) => (options) => {
     return {
-      task: camelCaseToDash(prop),
+      task: isPath(prop) ? prop : camelCaseToDash(prop),
       options,
     };
   }

--- a/packages/haste-core/src/runner.js
+++ b/packages/haste-core/src/runner.js
@@ -45,9 +45,9 @@ module.exports = class Runner extends Tapable {
 
   run(...taskDefs) {
     const tasks = taskDefs
-      .map(({ task: name, options }) => {
+      .map(({ task: name, options, metadata }) => {
         const worker = this.resolveWorker(name);
-        const task = new Task({ options, worker });
+        const task = new Task({ options, worker, metadata });
 
         return task;
       });

--- a/packages/haste-core/src/task.js
+++ b/packages/haste-core/src/task.js
@@ -1,11 +1,12 @@
 const Tapable = require('tapable');
 
 module.exports = class extends Tapable {
-  constructor({ worker, options }) {
+  constructor({ worker, options, metadata = {} }) {
     super();
 
     this.worker = worker;
     this.options = options;
+    this.metadata = metadata;
   }
 
   get name() {

--- a/packages/haste-core/src/utils.js
+++ b/packages/haste-core/src/utils.js
@@ -19,3 +19,5 @@ module.exports.resolveTaskName = (taskName, runContext) => {
 };
 
 module.exports.camelCaseToDash = str => str.replace(/([a-z])([A-Z])/g, '$1-$2').toLowerCase();
+
+module.exports.isPath = str => path.basename(str) !== str;

--- a/packages/haste-core/test/haste.spec.js
+++ b/packages/haste-core/test/haste.spec.js
@@ -341,6 +341,23 @@ describe('haste', () => {
       });
     });
 
+    it('should use the second argument of the function notation as a the metadata object of the task object', async () => {
+      const start = haste();
+
+      return start(async (configure) => {
+        const { tasks } = configure({
+          plugins: [testPlugin]
+        });
+
+        const options = { value: 'some-value' };
+        const metadata = { title: 'awesome-task' };
+
+        const resultTaskObject = { task: loggingOptions, options, metadata };
+
+        expect(tasks[loggingOptions](options, metadata)).toEqual(resultTaskObject);
+      });
+    });
+
     it('should convert camelcase to dashes for non path task names', async () => {
       const start = haste();
 

--- a/packages/haste-core/test/haste.spec.js
+++ b/packages/haste-core/test/haste.spec.js
@@ -326,35 +326,33 @@ describe('haste', () => {
   });
 
   describe('function notation', () => {
-    it('should be supported for running tasks', async () => {
+    it('should return a task object which can be inserted into runner.run() calls', async () => {
       const start = haste();
 
       return start(async (configure) => {
-        runner = configure({
+        const { tasks } = configure({
           plugins: [testPlugin]
         });
 
         const options = { value: 'some-value' };
-        const result = await runner.run(runner.tasks[loggingOptions](options));
+        const resultTaskObject = { task: loggingOptions, options };
 
-        expect(result).toEqual('some-value');
-        expect(stdout).toEqual('logging-options-task\n{ value: \'some-value\' }\n');
+        expect(tasks[loggingOptions](options)).toEqual(resultTaskObject);
       });
     });
 
-    it('should convert camelcase to dashes', async () => {
-      const start = haste(path.join(__dirname, '/fixtures'));
+    it('should convert camelcase to dashes for non path task names', async () => {
+      const start = haste();
 
       return start(async (configure) => {
-        runner = configure({
+        const { tasks } = configure({
           plugins: [testPlugin]
         });
 
         const options = { value: 'some-value' };
-        const result = await runner.run(runner.tasks.successfulCamelCase(options));
+        const resultTaskObject = { task: 'camel-case-task', options };
 
-        expect(result).toEqual('some-value');
-        expect(stdout).toEqual('successful-camel-case-task\n{ value: \'some-value\' }\n');
+        expect(tasks.camelCaseTask(options)).toEqual(resultTaskObject);
       });
     });
   });

--- a/packages/haste-core/test/haste.spec.js
+++ b/packages/haste-core/test/haste.spec.js
@@ -57,7 +57,7 @@ describe('haste', () => {
     });
 
     it('should run an unsuccessful task and reject', async () => {
-      expect.assertions(3);
+      expect.assertions(2);
 
       const start = haste();
 
@@ -70,8 +70,7 @@ describe('haste', () => {
           await runner.run({ task: unsuccessful });
         } catch (error) {
           expect(error).toEqual('some-error');
-          expect(stdout).toMatch('unsuccessful-task\n');
-          expect(stdout).toMatch('some-error\n');
+          expect(stdout).toMatch(['unsuccessful-task\n', 'some-error\n'].join(''));
         }
       });
     });
@@ -92,7 +91,7 @@ describe('haste', () => {
         );
 
         expect(result).toEqual(undefined);
-        expect(stdout).toMatch('successful-task\nsuccessful-task\n');
+        expect(stdout).toMatch(['successful-task\n', 'successful-task\n'].join(''));
       });
     });
 
@@ -113,13 +112,13 @@ describe('haste', () => {
           );
         } catch (error) {
           expect(error).toEqual('some-error');
-          expect(stdout).toMatch('successful-task\nunsuccessful-task\nsome-error\n');
+          expect(stdout).toMatch(['successful-task\n', 'unsuccessful-task\n', 'some-error\n'].join(''));
         }
       });
     });
 
     it('should run a sequence of an unsuccessful task and a successful task and reject', async () => {
-      expect.assertions(3);
+      expect.assertions(2);
 
       const start = haste();
 
@@ -135,8 +134,7 @@ describe('haste', () => {
           );
         } catch (error) {
           expect(error).toEqual('some-error');
-          expect(stdout).toMatch('unsuccessful-task\n');
-          expect(stdout).toMatch('some-error\n');
+          expect(stdout).toMatch(['unsuccessful-task\n', 'some-error\n'].join(''));
         }
       });
     });
@@ -243,7 +241,7 @@ describe('haste', () => {
         );
 
         expect(result).toEqual('some-other-value');
-        expect(stdout).toEqual('returned-value-task\nlogging-value-task\nsome-value\n');
+        expect(stdout).toEqual(['returned-value-task\n', 'logging-value-task\n', 'some-value\n'].join(''));
       });
     });
 
@@ -258,7 +256,7 @@ describe('haste', () => {
         const result = await runner.run({ task: loggingOptions, options: { value: 'some-value' } });
 
         expect(result).toEqual('some-value');
-        expect(stdout).toEqual('logging-options-task\n{ value: \'some-value\' }\n');
+        expect(stdout).toEqual(['logging-options-task\n', '{ value: \'some-value\' }\n'].join(''));
       });
     });
 


### PR DESCRIPTION
* task can now add metadata object, and later on use it in plugins.

```js
// on preset
const webpackProduction = {
  task: 'webpack',
  metadata: {
    title: 'webpack-production',
  },
  options: {
    configPath: paths.config.webpack.production
  }
};

run(webpackProduction);
```

```js
// on plugin
apply(runner) {
  runner.plugin('start-run', (runPhase) => {
    console.log(runPhase.tasks[0].metadata.title) // webpack-production
  })
}
```

* A small refactor to the testPlugin
  * The test plugin can now emit `start-run` event to a `runPhase` stub, so we can make assertions on it.
  * The test plugin is initialized before each test (less repetition on the constructor with the stubs)
  * Simplify stdout mock usage, change it from a mock to a string which you can use `.toMatch` function in order to match output. It will remove the flakiness that caused due to stdout falling into different calls of the former `jest.fn()` mock.

* Improve tests of the function notation to test the result object and not actually run the runner.
* Fix function notation bug of converting path to lowercase when it is not needed.
* Add the metadata feature as a second argument to the function notation.