### PR TITLE
improve logging to work with runPhases and titles instead of task names

### DIFF
--- a/packages/haste-plugin-loader/src/utils.js
+++ b/packages/haste-plugin-loader/src/utils.js
@@ -6,11 +6,20 @@ module.exports.delta = (start) => {
 };
 
 module.exports.generateRunTitle = (tasks) => {
-  if (tasks[0].name === 'read' && tasks[1].name === 'write') {
-    return 'copy';
+  const READ = 'read';
+  const WRITE = 'write';
+  const COPY = 'copy';
+
+  // if there are two tasks which are "read" and "write" with no titles call it copy
+  if (tasks.length === 2 && !tasks[0].metadata.title && !tasks[1].metadata.title) {
+    if (tasks[0].name === READ && tasks[1].name === WRITE) {
+      return COPY;
+    }
   }
 
   return tasks
-    .filter(t => !['read', 'write'].includes(t.name))
-    .map(task => task.name).join(',');
+    // filter any "read"/"write" tasks that has no title
+    .filter(task => task.metadata.title || ![READ, WRITE].includes(task.name))
+    // try to use the title of a task if exist and default to the task name
+    .map(task => task.metadata.title || task.name).join(',');
 };

--- a/packages/haste-plugin-logger/src/index.js
+++ b/packages/haste-plugin-logger/src/index.js
@@ -1,5 +1,5 @@
 const chalk = require('chalk');
-const { format, delta } = require('./utils');
+const { format, delta, generateRunTitle } = require('./utils');
 
 module.exports = class LoggerPlugin {
   apply(runner) {
@@ -8,23 +8,19 @@ module.exports = class LoggerPlugin {
     });
 
     runner.plugin('start-run', (runPhase) => {
-      runPhase.tasks.forEach((task) => {
-        let start;
+      const runTitle = generateRunTitle(runPhase.tasks);
 
-        task.plugin('start-task', () => {
-          start = new Date();
-          console.log(`[${format(start)}] ${chalk.black.bgGreen('Starting')} '${task.name}'...`);
-        });
+      const start = new Date();
+      console.log(`[${format(start)}] ${chalk.black.bgGreen('Starting')} '${runTitle}'...`);
 
-        task.plugin('succeed-task', () => {
-          const [end, time] = delta(start);
-          console.log(`[${format(end)}] ${chalk.black.bgCyan('Finished')} '${task.name}' after ${time} ms`);
-        });
+      runPhase.plugin('succeed-run', () => {
+        const [end, time] = delta(start);
+        console.log(`[${format(end)}] ${chalk.black.bgCyan('Finished')} '${runTitle}' after ${time} ms`);
+      });
 
-        task.plugin('failed-task', () => {
-          const [end, time] = delta(start);
-          console.log(`[${format(end)}] ${chalk.white.bgRed('Failed')} '${task.name}' after ${time} ms`);
-        });
+      runPhase.plugin('failed-run', () => {
+        const [end, time] = delta(start);
+        console.log(`[${format(end)}] ${chalk.white.bgRed('Failed')} '${runTitle}' after ${time} ms`);
       });
     });
   }

--- a/packages/haste-plugin-logger/src/utils.js
+++ b/packages/haste-plugin-logger/src/utils.js
@@ -6,3 +6,22 @@ module.exports.delta = (start) => {
 
   return [end, time];
 };
+
+module.exports.generateRunTitle = (tasks) => {
+  const READ = 'read';
+  const WRITE = 'write';
+  const COPY = 'copy';
+
+  // if there are two tasks which are "read" and "write" with no titles call it copy
+  if (tasks.length === 2 && !tasks[0].metadata.title && !tasks[1].metadata.title) {
+    if (tasks[0].name === READ && tasks[1].name === WRITE) {
+      return COPY;
+    }
+  }
+
+  return tasks
+    // filter any "read"/"write" tasks that has no title
+    .filter(task => task.metadata.title || ![READ, WRITE].includes(task.name))
+    // try to use the title of a task if exist and default to the task name
+    .map(task => task.metadata.title || task.name).join(',');
+};


### PR DESCRIPTION
* Aggregate start and end logs in logger to runs instead of tasks.
* Change `read` + `write` to `copy`.
* Accept `title` metadata when exist.
* update loader with same changes.

__NOTE:__ Right now we have code duplications between plugins about that stuff, we should probably export those functions to an external repository.