### PR TITLE
runner now has an 'idle' state 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Bug Fixes
  - do not exit on run failure when persistent flag is configured
 
+### Added
+ - runner has an 'idle' state when configured to be persistent and finished the initial runrun
+
 ## 0.1.3 - 2017-10-23
 
 ### Added

--- a/packages/haste-cli/bin/haste.js
+++ b/packages/haste-cli/bin/haste.js
@@ -51,8 +51,8 @@ explorer.load(context)
     }
 
     return run(command, [argv, result.config])
-      .then(({ persistent }) => {
-        if (!persistent) {
+      .then((runner) => {
+        if (!runner.persistent) {
           process.exit(0);
         }
       })

--- a/packages/haste-core/src/haste.js
+++ b/packages/haste-core/src/haste.js
@@ -38,8 +38,12 @@ module.exports = context => (action, params = []) => {
 
   return action(configure, ...params)
     .then(() => {
+      if (runner.persistent) {
+        runner.idle = true;
+      }
+
       runner.applyPlugins('finish-success');
-      return { persistent: runner.persistent };
+      return runner;
     })
     .catch((error) => {
       runner.applyPlugins('finish-failure', error);

--- a/packages/haste-core/src/runner.js
+++ b/packages/haste-core/src/runner.js
@@ -15,6 +15,7 @@ module.exports = class Runner extends Tapable {
 
     this.context = context;
     this.workers = {};
+    this.idle = false;
 
     process.on('exit', () => this.close());
   }

--- a/packages/haste-core/test/haste.spec.js
+++ b/packages/haste-core/test/haste.spec.js
@@ -287,6 +287,26 @@ describe('haste', () => {
         expect(firstRunPhase.tasks[0].metadata).toEqual({ title: 'awesome-task' });
       });
     });
+
+    it('should pass persistent property when configured in preset', async () => {
+      const start = haste();
+
+      const { persistent } = await start(async (configure) => {
+        runner = configure({ persistent: true });
+      });
+
+      expect(persistent).toBe(true);
+    });
+
+    it('should pass idle property that is true when initial run is done on persistent mode', async () => {
+      const start = haste();
+
+      const { idle } = await start(async (configure) => {
+        runner = configure({ persistent: true });
+      });
+
+      expect(idle).toBe(true);
+    });
   });
 
   describe('run context', () => {


### PR DESCRIPTION
when configured to be persistent and finished the initial run