### PR TITLE
haste-plugin-stats

### DIFF
--- a/packages/haste-cli/bin/haste.js
+++ b/packages/haste-cli/bin/haste.js
@@ -50,7 +50,7 @@ explorer.load(context)
       throw new Error(`${result.config.preset} doesn't support command ${cmd}`);
     }
 
-    return run(command, [argv, result.config])
+    return run(command, [argv, result.config], cmd)
       .then((runner) => {
         if (!runner.persistent) {
           process.exit(0);

--- a/packages/haste-core/src/haste.js
+++ b/packages/haste-core/src/haste.js
@@ -19,14 +19,14 @@ const tasks = new Proxy({}, {
   }
 });
 
-module.exports = context => (action, params = []) => {
+module.exports = context => (action, params = [], name) => {
   const runner = new Runner(context);
 
   const configure = ({ plugins = [], persistent = false } = {}) => {
     runner.persistent = persistent;
 
     runner.apply(...plugins);
-    runner.applyPlugins('start');
+    runner.applyPlugins('start', { params, name });
 
     return {
       tasks,

--- a/packages/haste-plugin-stats/README.md
+++ b/packages/haste-plugin-stats/README.md
@@ -1,0 +1,40 @@
+# Haste-plugin-stats
+Saves statistics of your build history
+
+
+## why ?
+Other plugins can later use this file to create various awesome features.
+
+1. Time estimation based on last builds.
+2. Build monitoring.
+3. Investigate why your build time drastically changed.
+4. Find frequent errors.
+
+and more...
+
+## usage
+Just add the plugin in your configure function
+
+```js
+const StatsPlugin = require('haste-plugin-stats');
+
+const { run, tasks } = configure({
+    plugins: [
+      new StatsPlugin()
+    ],
+  });
+```
+
+__important!__ The stats file should stay out of your version control, put it on `.gitignore`.
+
+## options
+* **base `<string>` :** the root directory which the file is saved in (defaults to process.cwd())
+* **directory `<string>` :** the directory to put the stats files (defaults to 'build-stats')
+* **filename `<string>` :** the filename to save the stats, due to multiple actions/commands you can also write a pattern with a name variable which will be the action name (defaults to 'haste-stats-[name]')
+
+## The problems
+If we want this plugin to have a significant effect, other plugins should rely on its existence.
+
+If we'll let users change its location via options, other plugins wouldn't know.
+One solution is to configure it statically via package.json for example.
+Another solution is not to configure it at all.

--- a/packages/haste-plugin-stats/package.json
+++ b/packages/haste-plugin-stats/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "haste-plugin-stats",
+  "version": "0.1.5",
+  "main": "./src/index.js",
+  "license": "MIT",
+  "dependencies": {
+    "mkdirp": "^0.5.1"
+  }
+}

--- a/packages/haste-plugin-stats/src/constants.js
+++ b/packages/haste-plugin-stats/src/constants.js
@@ -1,0 +1,2 @@
+module.exports.defaultStatsDir = 'build-stats';
+module.exports.defaultFilenamePattern = 'haste-stats-[name]';

--- a/packages/haste-plugin-stats/src/index.js
+++ b/packages/haste-plugin-stats/src/index.js
@@ -1,0 +1,167 @@
+const fs = require('fs');
+const path = require('path');
+const mkdirp = require('mkdirp');
+const { defaultStatsDir, defaultFilenamePattern } = require('./constants');
+const { delta, parseFileNamePattern } = require('./utils');
+
+module.exports = class StatsPlugin {
+  constructor({
+    base = process.cwd(),
+    directory = defaultStatsDir,
+    filename = defaultFilenamePattern
+  } = {}) {
+    this.base = base;
+    this.directory = directory;
+    this.filenamePattern = filename;
+    this.name;
+    this.persistent;
+    this.start;
+    this.end;
+    this.status;
+    this.error;
+    this.delta;
+    this.runs = [];
+    this.tasks = [];
+  }
+
+  addDeltas() {
+    this.delta = delta(this.start, this.end);
+
+    this.runs = this.runs.map((run) => {
+      run.delta = delta(run.start, run.end); // eslint-disable-line
+      return run;
+    });
+
+    this.tasks = this.runs.map((task) => {
+      task.delta = delta(task.start, task.end); // eslint-disable-line
+      return task;
+    });
+  }
+
+  statsObject() {
+    return {
+      name: this.name,
+      persistent: this.persistent,
+      start: this.start,
+      end: this.end,
+      delta: this.delta,
+      status: this.status,
+      runs: this.runs,
+      tasks: this.tasks,
+    };
+  }
+
+  preSave() {
+    this.addDeltas();
+  }
+
+  save() {
+    this.preSave();
+    const statsDirPath = path.join(this.base, this.directory);
+    const filename = parseFileNamePattern(this.filenamePattern, this.name);
+    const statsFilePath = path.join(statsDirPath, filename);
+    const currentSequence = this.statsObject();
+
+    try {
+      const sequences = JSON.parse(fs.readFileSync(statsFilePath));
+      sequences.unshift(currentSequence);
+      fs.writeFileSync(statsFilePath, JSON.stringify(sequences, null, 2));
+    } catch (e) {
+      if (e.code !== 'ENOENT') {
+        throw e;
+      }
+
+      mkdirp.sync(statsDirPath);
+      fs.writeFileSync(statsFilePath, JSON.stringify([currentSequence], null, 2));
+    }
+  }
+
+  apply(runner) {
+    this.persistent = runner.persistent;
+
+    runner.plugin('start', ({ name }) => {
+      this.name = name;
+      this.start = new Date();
+    });
+
+    runner.plugin('start-run', (runPhase) => {
+      const startRun = new Date();
+      const runName = runPhase.tasks.map(t => t.name).join(', ');
+
+      runPhase.tasks.forEach((task) => {
+        let startTask;
+
+        task.plugin('start-task', () => {
+          startTask = new Date();
+        });
+
+        task.plugin('succeed-task', () => {
+          const endTask = new Date();
+
+          const taskStats = {
+            start: startTask,
+            end: endTask,
+            name: task.name,
+            status: 'succeed',
+          };
+
+          this.tasks.push(taskStats);
+        });
+
+        task.plugin('failed-task', (error) => {
+          const endTask = new Date();
+
+          const taskStats = {
+            start: startTask,
+            end: endTask,
+            name: task.name,
+            error,
+            status: 'failed'
+          };
+
+          this.tasks.push(taskStats);
+        });
+      });
+
+      runPhase.plugin('succeed-run', () => {
+        const endRun = new Date();
+
+        const runStats = {
+          start: startRun,
+          end: endRun,
+          name: runName,
+          status: 'succeed'
+        };
+
+        this.runs.push(runStats);
+      });
+
+      runPhase.plugin('failed-run', (error) => {
+        const endRun = new Date();
+
+        const runStats = {
+          start: startRun,
+          end: endRun,
+          error,
+          name: runName,
+          status: 'failed'
+        };
+
+        this.runs.push(runStats);
+      });
+    });
+
+    runner.plugin('finish-success', () => {
+      this.end = new Date();
+      this.status = 'succeed';
+      this.save();
+    });
+
+    runner.plugin('finish-failure', (error) => {
+      this.end = new Date();
+      this.error = error;
+      this.status = 'failed';
+      this.save();
+    });
+  }
+};

--- a/packages/haste-plugin-stats/src/utils.js
+++ b/packages/haste-plugin-stats/src/utils.js
@@ -1,0 +1,7 @@
+module.exports.delta = (start, end) => {
+  return Math.abs(end.getTime() - start.getTime());
+};
+
+module.exports.parseFileNamePattern = (pattern, name) => {
+  return `${pattern.replace('[name]', name)}.json`;
+};

--- a/packages/haste-preset-fullstack/package.json
+++ b/packages/haste-preset-fullstack/package.json
@@ -7,6 +7,7 @@
     "haste-plugin-dashboard": "^0.1.3",
     "haste-plugin-loader": "^0.1.3",
     "haste-plugin-logger": "^0.1.3",
+    "haste-plugin-stats": "^0.1.5",
     "haste-task-babel": "^0.1.4",
     "haste-task-clean": "^0.1.0",
     "haste-task-copy": "^0.0.2",

--- a/packages/haste-preset-fullstack/src/commands/build.js
+++ b/packages/haste-preset-fullstack/src/commands/build.js
@@ -1,10 +1,12 @@
 const LoaderPlugin = require('haste-plugin-loader');
+const StatsPlugin = require('haste-plugin-stats');
 const paths = require('../../config/paths');
 
 module.exports = async (configure) => {
   const { run, tasks } = configure({
     plugins: [
       new LoaderPlugin({ oneLinerTasks: false }),
+      new StatsPlugin()
     ],
   });
 


### PR DESCRIPTION
# Haste-plugin-stats
Saves statistics of your build history


## why ?
Other plugins can later use this file to create various awesome features.

1. Time estimation based on last builds.
2. Build monitoring.
3. Investigate why your build time drastically changed.
4. Find frequent errors.

and more...

## usage
Just add the plugin in your configure function

```js
const StatsPlugin = require('haste-plugin-stats');

const { run, tasks } = configure({
    plugins: [
      new StatsPlugin()
    ],
  });
```

__important!__ The stats file should stay out of your version control, put it on `.gitignore`.

## options
* **base `<string>` :** the root directory which the file is saved in (defaults to process.cwd())
* **directory `<string>` :** the directory to put the stats files (defaults to 'build-stats')
* **filename `<string>` :** the filename to save the stats, due to multiple actions/commands you can also write a pattern with a name variable which will be the action name (defaults to 'haste-stats-[name]')

## The problems
If we want this plugin to have a significant effect, other plugins should rely on its existence.

If we'll let users change its location via options, other plugins wouldn't know.
One solution is to configure it statically via package.json for example.
Another solution is not to configure it at all.