### PR TITLE
haste-task-eslint: move eslint to be a peer dependency

### DIFF
--- a/packages/haste-task-eslint/package.json
+++ b/packages/haste-task-eslint/package.json
@@ -3,7 +3,10 @@
   "version": "0.1.0",
   "main": "./src/index.js",
   "license": "MIT",
-  "dependencies": {
+  "peerDependencies": {
+    "eslint": ">=1.6.0 <5.0.0"
+  },
+  "devDependencies": {
     "eslint": "^4.8.0"
   }
 }


### PR DESCRIPTION
We're considering to move all (or most) tasks to use `peerDependencies` for their 3rd parties. This will allow presets to decide on the versions of 3rd party libraries.

This change only affects eslint but other tasks may follow with a similar change.