### PR TITLE
set max listeners on stdout and stderr to 100 for cases with more than 10 workers (the default)

### DIFF
--- a/packages/haste-plugin-logger/src/index.js
+++ b/packages/haste-plugin-logger/src/index.js
@@ -3,8 +3,12 @@ const { format, delta, generateRunTitle } = require('./utils');
 
 module.exports = class LoggerPlugin {
   apply(runner) {
+    const keys = ['stdout', 'stderr'];
+
+    keys.forEach(key => process[key].setMaxListeners(100));
+
     runner.plugin('start-worker', (worker) => {
-      ['stdout', 'stderr'].forEach(name => worker.child[name].pipe(process[name]));
+      keys.forEach(key => worker.child[key].pipe(process[key]));
     });
 
     runner.plugin('start-run', (runPhase) => {


### PR DESCRIPTION
This is a quick solution for the warning message when using more than 10 different tasks.