### PR TITLE
limit jest max workers to 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "scripts": {
     "bootstrap": "lerna bootstrap",
     "lint": "eslint .",
-    "test:coverage": "jest --coverage && codecov",
+    "test:coverage": "jest --coverage --maxWorkers=2 && codecov",
     "test:watch": "jest --watch",
     "test": "jest",
     "build": "npm run bootstrap && npm run lint"


### PR DESCRIPTION
Jest started to run very slowly lately, and some tests got to their timeout limit because of other tests that were written. jest tries to run the tests in parallel but on CI it only has 2 cores.

(Travis has only 2 cores on the free oss plan).

http://facebook.github.io/jest/docs/en/troubleshooting.html#tests-are-extremely-slow-on-docker-and-or-continuous-integration-ci-server

So let's configure jest to use only 2 workers on CI, stop the flakiness in our tests and make them run faster.

