### PR TITLE
haste-task-read accepts a filter function

### DIFF
--- a/packages/haste-task-read/README.md
+++ b/packages/haste-task-read/README.md
@@ -1,0 +1,38 @@
+# haste-task-read
+Haste task for reading files from the file system.
+
+The task returns a promise with an array of virtual files:
+
+* a virtaul file consist of two things:
+  1. filename `<string>` - an absolute path to the file.
+  2. content `<string>` - the content of the file encoded to `utf-8`.
+```js
+read({ pattern: '**.*'})
+  .then(virtualFiles => console.log(virtualFiles))
+
+// [{ filename: "/path/to/file.js", content: "file content"}]
+
+```
+## options
+
+#### pattern
+
+Type: `string`
+
+A glob pattern, uses [globby](https://github.com/sindresorhus/globby) under the hood.
+
+#### filter
+
+Type: `function`
+
+A filter function that gets the identified filenames from the glob pattern and can filter them through a custom rule.
+
+```js
+
+// take only file without underscore prefix
+
+read({
+  pattern: '**.*',
+  filter: (filename) => noUnderscorePrefix(filename)
+})
+```

--- a/packages/haste-task-read/src/index.js
+++ b/packages/haste-task-read/src/index.js
@@ -5,8 +5,12 @@ const readFile = file => new Promise((resolve, reject) => {
   fs.readFile(file, 'utf8', (err, data) => err ? reject(err) : resolve(data));
 });
 
-module.exports = ({ pattern }) => async () => {
-  const files = await globby(pattern, { nodir: true });
+module.exports = ({ pattern, filter: filterFunction }) => async () => {
+  let files = await globby(pattern, { nodir: true });
+
+  if (filterFunction) {
+    files = files.filter(filterFunction);
+  }
 
   return Promise.all(
     files.map((filename) => {

--- a/packages/haste-task-read/test/fixtures/filter/_file.txt
+++ b/packages/haste-task-read/test/fixtures/filter/_file.txt
@@ -1,0 +1,1 @@
+some-content

--- a/packages/haste-task-read/test/fixtures/filter/file.txt
+++ b/packages/haste-task-read/test/fixtures/filter/file.txt
@@ -1,0 +1,1 @@
+some-content

--- a/packages/haste-task-read/test/index.spec.js
+++ b/packages/haste-task-read/test/index.spec.js
@@ -3,11 +3,12 @@ const path = require('path');
 const read = require('../src');
 
 describe('haste-read', () => {
-  const resolve = filename => path.join(__dirname, 'fixtures', filename);
+  const resolve = (...pathParts) => path.join(__dirname, 'fixtures', ...pathParts);
   const filename = resolve('file.txt');
-  const nestedFilename = resolve('nested/folder/structure/nested.txt');
+  const nestedFilename = resolve('nested', 'folder', 'structure', 'nested.txt');
+  const filteredFilename = resolve('filter', 'file.txt');
 
-  it('should read from a filename', () => {
+  it('should read from a filename', async () => {
     const task = read({ pattern: filename });
 
     const expected = {
@@ -15,13 +16,12 @@ describe('haste-read', () => {
       content: fs.readFileSync(filename, 'utf8'),
     };
 
-    return task()
-      .then((result) => {
-        expect(result).toEqual([expected]);
-      });
+    const result = await task();
+
+    expect(result).toEqual([expected]);
   });
 
-  it('should read from a glob pattern', () => {
+  it('should read from a glob pattern', async () => {
     const pattern = resolve('**.*');
     const task = read({ pattern });
 
@@ -30,14 +30,29 @@ describe('haste-read', () => {
       content: fs.readFileSync(filename, 'utf8'),
     };
 
-    return task()
-      .then((result) => {
-        expect(result).toEqual([expected]);
-      });
+    const result = await task();
+
+    expect(result).toEqual([expected]);
   });
 
-  it('should not read directories', () => {
-    const pattern = resolve('nested/**');
+  it('should filter files using the passed filter function', async () => {
+    const pattern = resolve('filter', '**.*');
+    const noUnderscorePrefix = str => !path.basename(str).startsWith('_');
+
+    const task = read({ pattern, filter: noUnderscorePrefix });
+
+    const expected = {
+      filename: filteredFilename,
+      content: fs.readFileSync(filteredFilename, 'utf8'),
+    };
+
+    const result = await task();
+
+    expect(result).toEqual([expected]);
+  });
+
+  it('should not read directories', async () => {
+    const pattern = resolve('nested', '**');
     const task = read({ pattern });
 
     const expected = {
@@ -45,9 +60,8 @@ describe('haste-read', () => {
       content: fs.readFileSync(nestedFilename, 'utf8'),
     };
 
-    return task()
-      .then((result) => {
-        expect(result).toEqual([expected]);
-      });
+    const result = await task();
+
+    expect(result).toEqual([expected]);
   });
 });


### PR DESCRIPTION
enables filtering after the glob pattern, base on the file paths.