### PR TITLE
haste-task-read: fix 'filename' prop name always being absolute instead of being relative

### DIFF
--- a/packages/haste-task-read/src/index.js
+++ b/packages/haste-task-read/src/index.js
@@ -17,9 +17,10 @@ module.exports = ({ pattern, options: { cwd = process.cwd(), ...options } = {} }
 
   return Promise.all(
     files
-      .map(filename => path.isAbsolute(filename) ? filename : path.join(cwd, filename))
       .map((filename) => {
-        return readFile(filename)
+        const absoluteFilePath = path.isAbsolute(filename) ? filename : path.join(cwd, filename);
+
+        return readFile(absoluteFilePath)
           .then((content) => {
             return {
               content,

--- a/packages/haste-task-read/test/index.spec.js
+++ b/packages/haste-task-read/test/index.spec.js
@@ -58,7 +58,7 @@ describe('haste-read', () => {
     const task = read({ pattern, options: { cwd } });
 
     const expected = {
-      filename,
+      filename: 'file.txt',
       content: fs.readFileSync(filename, 'utf8'),
       cwd,
     };


### PR DESCRIPTION
This fixes a problem introduced in #132: `filename` prop should be relative to `cwd`, instead it's now absolute.

This PR fixes that.