### PR TITLE
Haste task protractor fixes

### DIFF
--- a/packages/haste-task-protractor/package.json
+++ b/packages/haste-task-protractor/package.json
@@ -4,6 +4,7 @@
   "main": "./src/index.js",
   "license": "MIT",
   "dependencies": {
+    "dargs": "^5.1.0",
     "execa": "^0.8.0",
     "protractor": "^5.1.2"
   },

--- a/packages/haste-task-protractor/src/index.js
+++ b/packages/haste-task-protractor/src/index.js
@@ -7,7 +7,7 @@ const WEBDRIVER_BIN = require.resolve('protractor/bin/webdriver-manager');
 const defaultOptions = { standalone: true, gecko: 'false' };
 
 module.exports = ({ configPath, webdriverManagerOptions = {} }) => async () => {
-  const options = Object.assign(defaultOptions, webdriverManagerOptions);
+  const options = { ...defaultOptions, ...webdriverManagerOptions };
   const args = dargs(options, { allowCamelCase: true, useEquals: false, ignoreFalse: false });
 
   await execa(WEBDRIVER_BIN, ['update', ...args], { stdio: 'inherit' });

--- a/packages/haste-task-protractor/src/index.js
+++ b/packages/haste-task-protractor/src/index.js
@@ -1,11 +1,15 @@
 const execa = require('execa');
+const dargs = require('dargs');
 
 const PROTRACTOR_BIN = require.resolve('protractor/bin/protractor');
 const WEBDRIVER_BIN = require.resolve('protractor/bin/webdriver-manager');
 
-const defaultArgs = ['--standalone', '--gecko', 'false'];
+const defaultOptions = { standalone: true, gecko: 'false' };
 
-module.exports = ({ configPath, webdriverManagerArgs = [] }) => async () => {
-  await execa(WEBDRIVER_BIN, ['update', ...defaultArgs, ...webdriverManagerArgs], { stdio: 'inherit' });
+module.exports = ({ configPath, webdriverManagerOptions = {} }) => async () => {
+  const options = Object.assign(defaultOptions, webdriverManagerOptions);
+  const args = dargs(options, { allowCamelCase: true, useEquals: false, ignoreFalse: false });
+
+  await execa(WEBDRIVER_BIN, ['update', ...args], { stdio: 'inherit' });
   await execa(PROTRACTOR_BIN, [configPath], { stdio: 'inherit' });
 };

--- a/packages/haste-task-protractor/test/index.spec.js
+++ b/packages/haste-task-protractor/test/index.spec.js
@@ -1,24 +1,19 @@
-jest.mock('execa');
-
-const execa = require('execa');
 const { run } = require('haste-test-utils');
-const protractor = require('../src/index');
 
 const { command: protractorCommand, kill } = run(require.resolve('../src'));
 
-jest.setTimeout(30000);
+jest.setTimeout(10000);
 
-describe('haste-protractor', () => {
+describe('haste-protractor e2e', () => {
   afterEach(kill);
 
   it('should run protractor with a passing test and resolve', async () => {
     const configPath = require.resolve('./fixtures/passing.conf.js');
     const { task, stdout } = protractorCommand({ configPath });
 
-    return task()
-      .then(() => {
-        expect(stdout()).toMatch(/1 spec, 0 failures/);
-      });
+    await task();
+
+    expect(stdout()).toMatch(/1 spec, 0 failures/);
   });
 
   it('should run protractor with a failing test and reject', async () => {
@@ -27,23 +22,19 @@ describe('haste-protractor', () => {
     const configPath = require.resolve('./fixtures/failing.conf.js');
     const { task, stdout } = protractorCommand({ configPath });
 
-    return task()
-      .catch(() => {
-        expect(stdout()).toMatch(/1 spec, 1 failure/);
-      });
+    try {
+      await task();
+    } catch (error) {
+      expect(stdout()).toMatch(/1 spec, 1 failure/);
+    }
   });
+});
 
-  it('should run protractor with a missing config and reject', async () => {
-    expect.assertions(1);
+describe('haste-protractor unit', () => {
+  jest.mock('execa');
 
-    const configPath = 'missing.conf.js';
-    const { task, stdout } = protractorCommand({ configPath });
-
-    return task()
-      .catch(() => {
-        expect(stdout()).toMatch(/Error message: failed loading configuration file missing.conf.js/);
-      });
-  });
+  const execa = require('execa');
+  const protractor = require('../src/index');
 
   it('should merge webdriver manager options with the default and transform to args', async () => {
     const webdriverManagerOptions = { gecko: 'true', standalone: true, 'versions.chrome': 2.29 };
@@ -51,6 +42,8 @@ describe('haste-protractor', () => {
     await protractor({ webdriverManagerOptions })();
 
     const expectedArgs = ['update', '--standalone', '--gecko', 'true', '--versions.chrome', '2.29'];
-    expect(execa.mock.calls[0][1]).toEqual(expectedArgs);
+    const passedArgs = execa.mock.calls[0][1];
+
+    expect(passedArgs).toEqual(expectedArgs);
   });
 });

--- a/packages/haste-task-protractor/test/index.spec.js
+++ b/packages/haste-task-protractor/test/index.spec.js
@@ -2,48 +2,50 @@ const { run } = require('haste-test-utils');
 
 const { command: protractorCommand, kill } = run(require.resolve('../src'));
 
-jest.setTimeout(10000);
+jest.setTimeout(30000);
 
-describe('haste-protractor e2e', () => {
-  afterEach(kill);
+describe('haste-protractor', () => {
+  describe('e2e', () => {
+    afterEach(kill);
 
-  it('should run protractor with a passing test and resolve', async () => {
-    const configPath = require.resolve('./fixtures/passing.conf.js');
-    const { task, stdout } = protractorCommand({ configPath });
+    it('should run protractor with a passing test and resolve', async () => {
+      const configPath = require.resolve('./fixtures/passing.conf.js');
+      const { task, stdout } = protractorCommand({ configPath });
 
-    await task();
-
-    expect(stdout()).toMatch(/1 spec, 0 failures/);
-  });
-
-  it('should run protractor with a failing test and reject', async () => {
-    expect.assertions(1);
-
-    const configPath = require.resolve('./fixtures/failing.conf.js');
-    const { task, stdout } = protractorCommand({ configPath });
-
-    try {
       await task();
-    } catch (error) {
-      expect(stdout()).toMatch(/1 spec, 1 failure/);
-    }
+
+      expect(stdout()).toMatch(/1 spec, 0 failures/);
+    });
+
+    it('should run protractor with a failing test and reject', async () => {
+      expect.assertions(1);
+
+      const configPath = require.resolve('./fixtures/failing.conf.js');
+      const { task, stdout } = protractorCommand({ configPath });
+
+      try {
+        await task();
+      } catch (error) {
+        expect(stdout()).toMatch(/1 spec, 1 failure/);
+      }
+    });
   });
-});
 
-describe('haste-protractor unit', () => {
-  jest.mock('execa');
+  describe('unit', () => {
+    jest.mock('execa');
 
-  const execa = require('execa');
-  const protractor = require('../src/index');
+    const execa = require('execa');
+    const protractor = require('../src/index');
 
-  it('should merge webdriver manager options with the default and transform to args', async () => {
-    const webdriverManagerOptions = { gecko: 'true', standalone: true, 'versions.chrome': 2.29 };
+    it('should merge webdriver manager options with the default and transform to args', async () => {
+      const webdriverManagerOptions = { gecko: 'true', standalone: true, 'versions.chrome': 2.29 };
 
-    await protractor({ webdriverManagerOptions })();
+      await protractor({ webdriverManagerOptions })();
 
-    const expectedArgs = ['update', '--standalone', '--gecko', 'true', '--versions.chrome', '2.29'];
-    const passedArgs = execa.mock.calls[0][1];
+      const expectedArgs = ['update', '--standalone', '--gecko', 'true', '--versions.chrome', '2.29'];
+      const passedArgs = execa.mock.calls[0][1];
 
-    expect(passedArgs).toEqual(expectedArgs);
+      expect(passedArgs).toEqual(expectedArgs);
+    });
   });
 });


### PR DESCRIPTION
* Change the `webdriverManagerArgs<Array>` option to be `webdriverManagerOptions<Object>`
* Fix the merge between the passed options with the default options.
* Refactor tests