### PR TITLE
haste-task-copy: (fix) use the cwd of the file instead of the cwd option to figure out the absolute path

### DIFF
--- a/packages/haste-task-copy/README.md
+++ b/packages/haste-task-copy/README.md
@@ -20,4 +20,4 @@ A relative/absolute path which the files will be copied relatively to.
 
 Type: `String`
 
-An absolute path which the target and the source will be relative to, defaults to `process.cwd()`.
+An absolute path which the target will be relative to, defaults to `process.cwd()`.

--- a/packages/haste-task-copy/src/index.js
+++ b/packages/haste-task-copy/src/index.js
@@ -21,8 +21,9 @@ const copyFile = (source, target) => new Promise((resolve, reject) => {
 
 module.exports = ({ cwd = process.cwd(), target }) => async (files) => {
   return Promise.all(
-    files.map(async ({ filename }) => {
-      const absoluteFilePath = path.join(cwd, filename);
+    files.map(async ({ filename, cwd: sourceCwd }) => {
+      const absoluteFilePath = path.isAbsolute(filename) ?
+        filename : path.join(sourceCwd, filename);
       const absoluteTarget = path.isAbsolute(target) ? target : path.join(cwd, target);
       const absoluteTargetFilePath = path.join(absoluteTarget, filename);
 

--- a/packages/haste-task-copy/test/index.spec.js
+++ b/packages/haste-task-copy/test/index.spec.js
@@ -19,7 +19,7 @@ describe('haste-copy', () => {
   });
 
   it('should copy files into target directory using absolute target path', async () => {
-    const file = { filename: 'file.txt' };
+    const file = { filename: 'file.txt', cwd: projectDir };
     const sourcePath = require.resolve(`./fixtures/${file.filename}`);
     const absoluteTargetPath = path.join(projectDir, target);
     const sourceContent = fs.readFileSync(sourcePath, 'utf8');
@@ -36,7 +36,7 @@ describe('haste-copy', () => {
   });
 
   it('should copy files into target directory using relative target path', async () => {
-    const file = { filename: 'file.txt' };
+    const file = { filename: 'file.txt', cwd: projectDir };
     const sourcePath = require.resolve(`./fixtures/${file.filename}`);
     const sourceContent = fs.readFileSync(sourcePath, 'utf8');
 
@@ -52,7 +52,7 @@ describe('haste-copy', () => {
   });
 
   it('should copy binary files', async () => {
-    const file = { filename: 'logo.png' };
+    const file = { filename: 'logo.png', cwd: projectDir };
     const sourcePath = require.resolve(`./fixtures/${file.filename}`);
     const sourceContent = fs.readFileSync(sourcePath, 'utf8');
 
@@ -69,7 +69,7 @@ describe('haste-copy', () => {
 
   it('should copy a file and create the directory structure if it does not exist', async () => {
     const filename = './fixtures/logo.png';
-    const file = { filename };
+    const file = { filename, cwd: projectDir };
     const sourcePath = require.resolve(filename);
     const sourceContent = fs.readFileSync(sourcePath, 'utf8');
 
@@ -88,7 +88,7 @@ describe('haste-copy', () => {
     expect.assertions(1);
 
     const task = copy({ target, cwd: projectDir });
-    const file = { filename: 'does/not/exists/file.txt' };
+    const file = { filename: 'does/not/exists/file.txt', cwd: projectDir };
 
     try {
       await task([file]);


### PR DESCRIPTION
`haste-task-copy` will now use the `cwd` of the file from the read task instead of its own `cwd` option in order to figure out the absolute path of a file.

https://github.com/wix/haste/blob/master/packages/haste-task-read/README.md#haste-task-read