### PR TITLE
haste-task-tslint: correct tslint api usage

### DIFF
--- a/packages/haste-task-tslint/src/index.js
+++ b/packages/haste-task-tslint/src/index.js
@@ -1,27 +1,24 @@
-const { Linter, Configuration, findFormatter } = require('tslint');
+const { Linter, Configuration } = require('tslint');
 
-module.exports = ({ options = { formatter: 'prose' }, configurationFilePath = null } = {}) => async (files) => {
+function runLinter(options, configurationFilePath, files) {
   const linter = new Linter(options);
 
-  const results = await Promise.all(
-    files
-      .map(async ({ filename, content }) => {
-        const config = Configuration.findConfiguration(configurationFilePath, filename).results;
-        linter.lint(filename, content, config);
-        return linter.getResult();
-      })
-  );
+  files.forEach(({ filename, content }) => {
+    const config = Configuration.findConfiguration(configurationFilePath, filename).results;
+    linter.lint(filename, content, config);
+  });
 
-  const errorCount = results.reduce((acc, result) => acc + result.errorCount, 0);
+  return linter.getResult();
+}
 
-  if (errorCount) {
-    const FormatterConstructor = findFormatter(options.formatter);
-    const formatter = new FormatterConstructor();
+module.exports = ({ options = { formatter: 'prose' }, configurationFilePath = null } = {}) => (files) => {
+  try {
+    const { errorCount, output } = runLinter(options, configurationFilePath, files);
 
-    const failures = results.reduce((list, result) => list.concat(result.failures), []);
-
-    return Promise.reject(formatter.format(failures));
+    return errorCount > 0 ?
+      Promise.reject(output) :
+      Promise.resolve();
+  } catch (error) {
+    return Promise.reject(error);
   }
-
-  return Promise.resolve();
 };

--- a/packages/haste-task-tslint/test/index.spec.js
+++ b/packages/haste-task-tslint/test/index.spec.js
@@ -37,7 +37,7 @@ describe('haste-tslint', () => {
       });
   });
 
-  it('should reject if a tsconfig.json could not be found', () => {
+  it('should reject if a tslint.json could not be found', () => {
     expect.assertions(1);
 
     const task = tslint({
@@ -54,7 +54,6 @@ describe('haste-tslint', () => {
         expect(error.message).toMatch('Could not find config file');
       });
   });
-
 
   it('should pass configuration to the linter', () => {
     expect.assertions(1);


### PR DESCRIPTION
This PR corrects the way we use tslint API.

- Nothing is async here.
- `getResults()` aggregates all results, no need to call it every time we lint file. Moreover - it might emit duplicated errors this way (with a combination of `map`).
- `output` property is already formatted, `findFormatter` is redundant.

Btw, I'd exclude functions in `no-use-before-define` rule. I think it's better to first show the module's api itself (which is `module.exports` here) and not inner implementation (= `runLinter`), which is not necessarily interesting / harden code reading (you have to start from the EOF). 