### PR TITLE
haste-core: handle uncaughtException in worker

### DIFF
--- a/packages/haste-core/src/worker-bin.js
+++ b/packages/haste-core/src/worker-bin.js
@@ -17,6 +17,10 @@ process.on('message', ({ options = {}, input, id }) => {
     process.send({ type: 'failure', error, id });
   };
 
+  process.on('uncaughtException', (error) => {
+    handleError(error);
+  });
+
   let promise;
 
   try {


### PR DESCRIPTION
If we don't handle `uncaughtException` in the worker, a task could be hanged and the main process wouldn't know whether to resolve or reject.