### PR TITLE
Add a default Logger and a way to change it

### DIFF
--- a/packages/haste-core/package.json
+++ b/packages/haste-core/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "chokidar": "^1.7.0",
     "haste-worker-farm": "^0.1.15",
+    "haste-plugin-logger": "^0.1.22",
     "resolve-from": "^4.0.0",
     "tapable": "1.0.0-beta.3"
   }

--- a/packages/haste-core/src/create-runner.js
+++ b/packages/haste-core/src/create-runner.js
@@ -1,12 +1,10 @@
 const Runner = require('./runner');
+const Logger = require('haste-plugin-logger');
 
-module.exports = ({ plugins = [] } = {}) => {
+module.exports = ({ plugins = [], logger = new Logger() } = {}) => {
   const runner = new Runner();
 
-  plugins.forEach(plugin => plugin.apply(runner));
+  [...plugins, logger].forEach(plugin => plugin.apply(runner));
 
-  return {
-    command: (...args) => runner.command(...args),
-    watch: (...args) => runner.watch(...args),
-  };
+  return runner;
 };

--- a/packages/haste-core/src/runner.js
+++ b/packages/haste-core/src/runner.js
@@ -15,7 +15,7 @@ module.exports = class Runner {
   }
 
   command(action, { persistent = false } = {}) {
-    return async ({ context, workerOptions }) => {
+    return async ({ context, workerOptions } = {}) => {
       const execution = new Execution({
         action,
         context,

--- a/packages/haste-core/test/logger.spec.js
+++ b/packages/haste-core/test/logger.spec.js
@@ -1,0 +1,28 @@
+const { createRunner } = require('../src');
+
+describe('logger', () => {
+  it('should use the logger that supplied on the runner creation', async () => {
+    const spy = jest.fn();
+
+    class MockLogger {
+      apply(runner) {
+        runner.hooks.beforeExecution.tap('logger', spy);
+      }
+    }
+
+    const mockLogger = new MockLogger();
+    const runner = createRunner({ logger: mockLogger });
+    const command = runner.command(async () => {});
+
+    await command();
+
+    expect(spy).toBeCalled();
+  });
+
+  it('should use the default logger if there is no logger configured', async () => {
+    const { hooks } = createRunner();
+    const [firstHook] = hooks.beforeExecution.taps;
+
+    expect(firstHook.name).toBe('logger');
+  });
+});

--- a/packages/haste-test-utils-core/src/index.js
+++ b/packages/haste-test-utils-core/src/index.js
@@ -5,7 +5,7 @@ module.exports.createSetup = createRunner => async (fsObject) => {
   const { cwd, files } = await fsSetup(fsObject);
   const testPlugin = new TestPlugin();
 
-  const runner = createRunner({ plugins: [testPlugin] });
+  const runner = createRunner({ logger: testPlugin });
 
   const run = async (action, options = {}) => {
     await runner.command(action)({ workerOptions: { cwd }, ...options });


### PR DESCRIPTION
Every plugin can write to the stdout, but there is a big mess when more than 1 does it.

In order to make sure that there is only one, let's create a `logger` entity. It will be a plugin like any other, with the same capabilities, but the only difference is that it will be allowed (by convention) to write things to the console.

We understand that haste does not work properly without a default logger.
It will be easier to start with haste when there is no need to bring a logger. (less configuration required)

**In this PR:**
1. An option to add a logger at the time of the runner creation.
2. A default logger if there is no logger supplied.
3. Tests for the functionality above.
4. The `test-utils` shall now use the logger in order to override the default logger (which create a mess in the eyes while the tests are running)
5. An option to create a command without arguments. 