### PR TITLE
accept source option to copy files from a source directory

### DIFF
--- a/packages/haste-service-fs/src/read.js
+++ b/packages/haste-service-fs/src/read.js
@@ -2,28 +2,31 @@ const path = require('path');
 const globby = require('globby');
 const { readFile } = require('./utils');
 
-module.exports = async ({ pattern, options: { cwd = process.cwd(), ...options } = {} }) => {
+module.exports = async ({ pattern, source, cwd = process.cwd(), options } = {}) => {
+  if (source) {
+    cwd = path.isAbsolute(source) ? source : path.join(cwd, source);
+  }
+
   const defaultOptions = { nodir: true };
 
   const files = await globby(pattern, {
     ...defaultOptions,
-    ...options,
     cwd,
+    ...options,
   });
 
   return Promise.all(
-    files
-      .map((filename) => {
-        const absoluteFilePath = path.isAbsolute(filename) ? filename : path.join(cwd, filename);
+    files.map((filename) => {
+      const absoluteFilePath = path.isAbsolute(filename) ? filename : path.join(cwd, filename);
 
-        return readFile(absoluteFilePath)
-          .then((content) => {
-            return {
-              content,
-              filename,
-              cwd,
-            };
-          });
-      }),
+      return readFile(absoluteFilePath)
+        .then((content) => {
+          return {
+            content,
+            filename,
+            cwd,
+          };
+        });
+    }),
   );
 };

--- a/packages/haste-service-fs/test/read.spec.js
+++ b/packages/haste-service-fs/test/read.spec.js
@@ -36,7 +36,7 @@ describe('haste-service-fs', () => {
       expect(result).toEqual([expected]);
     });
 
-    it('should not read directories', async () => {
+    it('should read nested files but not the directories themselves', async () => {
       const pattern = resolve('nested', '**');
 
       const expected = {
@@ -60,7 +60,37 @@ describe('haste-service-fs', () => {
         cwd,
       };
 
-      const result = await read({ pattern, options: { cwd } });
+      const result = await read({ pattern, cwd });
+
+      expect(result).toEqual([expected]);
+    });
+
+    it('should use a relative path source option to read files from', async () => {
+      const pattern = resolve('nested', '**');
+      const source = 'nested';
+
+      const expected = {
+        filename: nestedFilename,
+        content: fs.readFileSync(nestedFilename, 'utf8'),
+        cwd: path.join(process.cwd(), source),
+      };
+
+      const result = await read({ pattern, source });
+
+      expect(result).toEqual([expected]);
+    });
+
+    it('should use an absolue path source option to read files from', async () => {
+      const pattern = resolve('nested', '**');
+      const absoluteSource = resolve('nested');
+
+      const expected = {
+        filename: nestedFilename,
+        content: fs.readFileSync(nestedFilename, 'utf8'),
+        cwd: absoluteSource,
+      };
+
+      const result = await read({ pattern, source: absoluteSource });
 
       expect(result).toEqual([expected]);
     });

--- a/packages/haste-task-copy/src/index.js
+++ b/packages/haste-task-copy/src/index.js
@@ -19,18 +19,20 @@ const copyFile = (source, target) => new Promise((resolve, reject) => {
   rd.pipe(wr);
 });
 
-module.exports = async ({ pattern, target, cwd = process.cwd() }, { fs: fsService }) => {
-  const files = await fsService.read({ pattern });
+module.exports = async ({ pattern, target, cwd = process.cwd(), source }, { fs: fsService }) => {
+  const files = await fsService.read({ pattern, cwd, source });
 
   return Promise.all(
     files.map(async ({ filename, cwd: sourceCwd }) => {
-      const absoluteFilePath = path.isAbsolute(filename) ?
-        filename : path.join(sourceCwd, filename);
+      const absoluteSourcePath = path.isAbsolute(filename) ?
+        filename :
+        path.join(sourceCwd, filename);
+
       const absoluteTarget = path.isAbsolute(target) ? target : path.join(cwd, target);
       const absoluteTargetFilePath = path.join(absoluteTarget, filename);
 
       await makeDir(path.dirname(absoluteTargetFilePath));
-      await copyFile(absoluteFilePath, absoluteTargetFilePath);
+      await copyFile(absoluteSourcePath, absoluteTargetFilePath);
     }),
   );
 };

--- a/packages/haste-task-copy/test/index.spec.js
+++ b/packages/haste-task-copy/test/index.spec.js
@@ -71,4 +71,38 @@ describe('haste-copy', () => {
 
     expect(test.files['dist/folder/structure/test.txt'].content).toEqual('hello world');
   });
+
+  it('should copy files inside of "source" option into target directory when source is relative to cwd', async () => {
+    test = await setup({
+      'folder/structure/test.txt': 'hello world',
+    });
+
+    await test.run(async ({ [taskPath]: copy }) => {
+      await copy({
+        pattern: '**/*.txt',
+        source: 'folder',
+        target: 'dist',
+      });
+    });
+
+    expect(test.files['dist/structure/test.txt'].content).toEqual('hello world');
+  });
+
+  it('should copy files inside of "source" option into target directory when source is absolute', async () => {
+    test = await setup({
+      'folder/structure/test.txt': 'hello world',
+    });
+
+    const absoluteSource = path.join(test.cwd, 'folder');
+
+    await test.run(async ({ [taskPath]: copy }) => {
+      await copy({
+        pattern: '**/*.txt',
+        source: absoluteSource,
+        target: 'dist',
+      });
+    });
+
+    expect(test.files['dist/structure/test.txt'].content).toEqual('hello world');
+  });
 });


### PR DESCRIPTION
Let's say that I want to copy all files from `src` directory into `dest` directory.
Today without supplying `source` you'll get the following:

```bash
├── root-directory
├── src
│    └── file.js
└── dist
     └── src
          └── file.js
```

But the wanted result would be:

```bash
├── root-directory
├── src
│    └── file.js
└─ dist
     └── file.js
```

by choosing a `source` directory and a `target` directory both should be relative to the `root-directory`.
You can get this result.
