### PR TITLE
Runner options

### DIFF
--- a/packages/haste-core/src/task.js
+++ b/packages/haste-core/src/task.js
@@ -18,9 +18,10 @@ module.exports = class Task {
       this.pool.kill();
     });
 
-    this.api = async (options) => {
+    this.api = async (taskOptions, runnerOptions) => {
       const run = {
-        options,
+        taskOptions,
+        runnerOptions,
         hooks: {
           success: new AsyncSeriesWaterfallHook(['options']),
           failure: new AsyncSeriesWaterfallHook(['options']),
@@ -30,7 +31,7 @@ module.exports = class Task {
       await this.hooks.before.promise(run);
 
       try {
-        const result = await this.pool.send({ options });
+        const result = await this.pool.send({ taskOptions });
         const newResult = await run.hooks.success.promise(result);
 
         return newResult;

--- a/packages/haste-core/test/haste.spec.js
+++ b/packages/haste-core/test/haste.spec.js
@@ -289,4 +289,26 @@ describe('haste', () => {
       expect(test.stdio.stdout).toMatch('successful');
     });
   });
+
+  describe('plugins', () => {
+    it('should pass runnerOptions as a second argument on a task run and get it from a plugin', async () => {
+      expect.assertions(1);
+
+      const title = 'tasky';
+
+      test = await setup();
+
+      test.runner.hooks.beforeExecution.tap('testing', (execution) => {
+        execution.hooks.createTask.tap('testing', (task) => {
+          task.hooks.before.tap('testing', (run) => {
+            expect(run.runnerOptions.title).toEqual(title);
+          });
+        });
+      });
+
+      await test.run(async ({ [successfulPath]: successful }) => {
+        await successful({}, { title });
+      });
+    });
+  });
 });

--- a/packages/haste-test-utils-core/src/index.js
+++ b/packages/haste-test-utils-core/src/index.js
@@ -29,5 +29,5 @@ module.exports.createSetup = createRunner => async (fsObject) => {
     },
   });
 
-  return { run, files, stdio, cwd, cleanup };
+  return { run, files, stdio, cwd, cleanup, runner };
 };

--- a/packages/haste-worker-farm/src/pool.js
+++ b/packages/haste-worker-farm/src/pool.js
@@ -35,14 +35,14 @@ module.exports = class Pool {
     });
   }
 
-  async send({ options }) {
+  async send({ taskOptions }) {
     if (this.ending) {
       throw new Error('Farm has ended, no more calls can be done to it');
     }
 
     return this.farm.request(async () => {
       const worker = this.resolveWorker() || this.forkWorker();
-      const result = await worker.send({ options });
+      const result = await worker.send({ options: taskOptions });
 
       const wrap = f => (...args) => this.farm.request(() => f(...args));
 


### PR DESCRIPTION
Enable to pass `runnerOptions` as a second argument along with the `taskOptions` for every `task.api` call.
Recieve this argument from the plugins and be able to later use it to configure the runner in various ways, like calling the spawned process with different options, to possibly change the `env` or add `--debug-brk`.
```js
const taskOptions = {};
const runnerOptions = { title: 'my-awesome-task' };

await task(taskOptions, runnerOptions);
```

**NOTE:** Also exported the runner from `haste-test-utils-core` to be able and make assertions on hooks.
