### PR TITLE
haste-core: kill all workers from one place when the main process exits

### DIFF
--- a/packages/haste-core/src/execution.js
+++ b/packages/haste-core/src/execution.js
@@ -12,6 +12,7 @@ module.exports = class Execution {
     this.persistent = persistent;
     this.context = context;
     this.farm = farm;
+    this.tasks = [];
 
     this.hooks = {
       createTask: new SyncHook(['task']),
@@ -30,9 +31,15 @@ module.exports = class Execution {
       workerOptions: { ...defaultWorkerOptions, ...this.workerOptions },
     });
 
+    this.tasks.push(task);
+
     this.hooks.createTask.call(task);
 
     return task;
+  }
+
+  stop() {
+    this.tasks.forEach(task => task.kill());
   }
 
   async execute() {

--- a/packages/haste-core/src/task.js
+++ b/packages/haste-core/src/task.js
@@ -14,10 +14,6 @@ module.exports = class Task {
       modulePath: this.modulePath,
     });
 
-    process.on('exit', () => {
-      this.pool.kill();
-    });
-
     this.api = async (taskOptions = {}, runnerOptions = {}) => {
       const run = {
         taskOptions,
@@ -47,5 +43,9 @@ module.exports = class Task {
     this.hooks = {
       before: new AsyncSeriesWaterfallHook(['options']),
     };
+  }
+
+  kill() {
+    this.pool.kill();
   }
 };


### PR DESCRIPTION
This PR will solve an issue of creating duplicate listeners instead of taking care the worker's termination from one main place.