### PR TITLE
haste-worker-farm: uncaughtException in worker will now log the error

### DIFF
--- a/packages/haste-worker-farm/src/worker-bin.js
+++ b/packages/haste-worker-farm/src/worker-bin.js
@@ -4,12 +4,7 @@ const serializeError = require('serialize-error');
 let api = null;
 let modulePath = null;
 
-process.on('uncaughtException', (error) => {
-  process.send({
-    type: 'PARENT_MESSAGE_ERROR',
-    error: serializeError(error),
-  });
-});
+process.on('uncaughtException', handleError);
 
 process.on('message', ({ type, options }) => {
   switch (type) {


### PR DESCRIPTION
Will be handled like any other worker error.

Fixed a bug that `uncaughtException`s was hidden from the users.