### PR TITLE
haste-task-eslint: support formatter

### DIFF
--- a/packages/haste-task-eslint/src/index.js
+++ b/packages/haste-task-eslint/src/index.js
@@ -6,7 +6,7 @@ module.exports = ({ pattern, options = {} }, { fs }) => new Promise(async (resol
   const filePaths = files.map(({ filename }) => filename);
   const report = cli.executeOnFiles(filePaths);
 
-  const formatter = cli.getFormatter();
+  const formatter = cli.getFormatter(options.formatter);
   options.fix && CLIEngine.outputFixes(report);
 
   const errors = CLIEngine.getErrorResults(report.results);

--- a/packages/haste-task-eslint/test/index.spec.js
+++ b/packages/haste-task-eslint/test/index.spec.js
@@ -48,4 +48,21 @@ describe('haste-eslint', () => {
 
     expect(test.files['fixable.js'].content).toBe('/foo {2}bar/');
   });
+
+  it('should support formatter', async () => {
+    expect.assertions(1);
+
+    test = await setup();
+
+    await test.run(async ({ [taskPath]: eslint }) => {
+      try {
+        await eslint({
+          pattern: require.resolve('./fixtures/valid.js'),
+          options: { rules: { 'no-console': 'error' }, formatter: 'checkstyle' },
+        });
+      } catch (error) {
+        expect(error.message).toMatch('message="Unexpected console statement. (no-console)"');
+      }
+    });
+  });
 });

--- a/packages/haste-task-eslint/test/index.spec.js
+++ b/packages/haste-task-eslint/test/index.spec.js
@@ -49,7 +49,7 @@ describe('haste-eslint', () => {
     expect(test.files['fixable.js'].content).toBe('/foo {2}bar/');
   });
 
-  it('should support formatter', async () => {
+  it('should support a formatter option', async () => {
     expect.assertions(1);
 
     test = await setup();


### PR DESCRIPTION
Allow passing a custom formatter option