### PR TITLE
add strip-ansi for karma output on tests

### DIFF
--- a/packages/haste-task-karma/package.json
+++ b/packages/haste-task-karma/package.json
@@ -14,6 +14,7 @@
     "haste-test-utils": "^0.2.5",
     "jasmine-core": "^2.8.0",
     "karma-jasmine": "^1.1.0",
+    "strip-ansi": "4.0.0",
     "karma-phantomjs-launcher": "^1.0.4"
   }
 }

--- a/packages/haste-task-karma/test/index.spec.js
+++ b/packages/haste-task-karma/test/index.spec.js
@@ -1,3 +1,4 @@
+const stripAnsi = require('strip-ansi');
 const { setup } = require('haste-test-utils');
 
 const taskPath = require.resolve('../src');
@@ -22,7 +23,7 @@ describe('haste-karma', () => {
       });
     });
 
-    expect(test.stdio.stdout).toMatch('Executed 1 of 1 SUCCESS');
+    expect(stripAnsi(test.stdio.stdout)).toMatch('Executed 1 of 1 SUCCESS');
   });
 
   it('should run a failing test and reject', async () => {
@@ -37,7 +38,7 @@ describe('haste-karma', () => {
         });
       } catch (error) {
         expect(error.message).toMatch('Karma failed with code 1');
-        expect(test.stdio.stdout).toMatch('Executed 1 of 1 (1 FAILED)');
+        expect(stripAnsi(test.stdio.stdout)).toMatch('Executed 1 of 1 (1 FAILED)');
       }
     });
   });
@@ -51,6 +52,6 @@ describe('haste-karma', () => {
       });
     });
 
-    expect(test.stdio.stdout).toMatch('Executed 1 of 1 SUCCESS');
+    expect(stripAnsi(test.stdio.stdout)).toMatch('Executed 1 of 1 SUCCESS');
   });
 });


### PR DESCRIPTION
karma tests are failing (probably due to versions change).

The output now has green/red colors and it's better to ignore that for the sake of the tests.