### PR TITLE
Tslint type check

### DIFF
--- a/packages/haste-task-tslint/test/fixtures/invalidTsConfig.json
+++ b/packages/haste-task-tslint/test/fixtures/invalidTsConfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "jsx": "react"
+  },
+  "include": [
+    "invalid.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}

--- a/packages/haste-task-tslint/test/fixtures/tsconfig.json
+++ b/packages/haste-task-tslint/test/fixtures/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "jsx": "react"
+  },
+  "include": [
+    "valid.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}

--- a/packages/haste-task-tslint/test/index.spec.js
+++ b/packages/haste-task-tslint/test/index.spec.js
@@ -4,25 +4,25 @@ const taskPath = require.resolve('../src');
 
 const pathToValidFile = require.resolve('./fixtures/valid.ts');
 const pathToInvalidFile = require.resolve('./fixtures/invalid.ts');
-const pathToConfiguration = require.resolve('./fixtures/tslint.json');
+const pathToTslintFile = require.resolve('./fixtures/tslint.json');
+const pathToValidTsconfigFile = require.resolve('./fixtures/tsconfig.json');
+const pathToInvalidTsconfigFile = require.resolve('./fixtures/invalidTsconfig.json');
 
 describe('haste-tslint', () => {
   let test;
-
-  afterEach(() => test.cleanup());
 
   it('should resolve for valid files', async () => {
     test = await setup();
 
     await test.run(async ({ [taskPath]: tslint }) => {
       await tslint({
-        pattern: pathToValidFile,
-        configurationFilePath: pathToConfiguration,
+        tsconfigFilePath: pathToValidTsconfigFile,
+        tslintFilePath: pathToTslintFile
       });
     });
   });
 
-  it('should reject for valid files', async () => {
+  it('should reject for invalid files', async () => {
     expect.assertions(1);
 
     test = await setup();
@@ -30,8 +30,8 @@ describe('haste-tslint', () => {
     await test.run(async ({ [taskPath]: tslint }) => {
       try {
         await tslint({
-          pattern: pathToInvalidFile,
-          configurationFilePath: pathToConfiguration,
+          tsconfigFilePath: pathToInvalidTsconfigFile,
+          tslintFilePath: pathToTslintFile,
         });
       } catch (error) {
         expect(error.message).toMatch('Calls to \'console.error\' are not allowed');
@@ -47,8 +47,24 @@ describe('haste-tslint', () => {
     await test.run(async ({ [taskPath]: tslint }) => {
       try {
         await tslint({
-          pattern: pathToValidFile,
-          configurationFilePath: 'no-file',
+          tsconfigFilePath: pathToValidTsconfigFile,
+          tslintFilePath: 'no-file',
+        });
+      } catch (error) {
+        expect(error.message).toMatch('Could not find config file');
+      }
+    });
+  });
+
+  it('should reject if a tslint.json was not provided', async () => {
+    expect.assertions(1);
+
+    test = await setup();
+
+    await test.run(async ({ [taskPath]: tslint }) => {
+      try {
+        await tslint({
+          tsconfigFilePath: pathToValidTsconfigFile,
         });
       } catch (error) {
         expect(error.message).toMatch('Could not find config file');
@@ -64,8 +80,8 @@ describe('haste-tslint', () => {
     await test.run(async ({ [taskPath]: tslint }) => {
       try {
         await tslint({
-          pattern: pathToInvalidFile,
-          configurationFilePath: pathToConfiguration,
+          tsconfigFilePath: pathToInvalidTsconfigFile,
+          tslintFilePath: pathToTslintFile,
           options: { formatter: 'verbose' },
         });
       } catch (error) {

--- a/packages/haste-task-tslint/test/index.spec.js
+++ b/packages/haste-task-tslint/test/index.spec.js
@@ -11,82 +11,125 @@ const pathToInvalidTsconfigFile = require.resolve('./fixtures/invalidTsconfig.js
 describe('haste-tslint', () => {
   let test;
 
-  it('should resolve for valid files', async () => {
-    test = await setup();
-
-    await test.run(async ({ [taskPath]: tslint }) => {
-      await tslint({
-        tsconfigFilePath: pathToValidTsconfigFile,
-        tslintFilePath: pathToTslintFile
+  describe('linter', () => {
+    it('should resolve for valid files', async () => {
+      test = await setup();
+  
+      await test.run(async ({ [taskPath]: tslint }) => {
+        await tslint({
+          tsconfigFilePath: pathToValidTsconfigFile,
+          tslintFilePath: pathToTslintFile
+        });
       });
     });
+  
+    it('should reject for invalid files', async () => {
+      expect.assertions(1);
+  
+      test = await setup();
+  
+      await test.run(async ({ [taskPath]: tslint }) => {
+        try {
+          await tslint({
+            tsconfigFilePath: pathToInvalidTsconfigFile,
+            tslintFilePath: pathToTslintFile,
+          });
+        } catch (error) {
+          expect(error.message).toMatch('Calls to \'console.error\' are not allowed');
+        }
+      });
+    });  
+    
+    it('should pass configuration to the linter', async () => {
+      expect.assertions(1);
+  
+      test = await setup();
+  
+      await test.run(async ({ [taskPath]: tslint }) => {
+        try {
+          await tslint({
+            tsconfigFilePath: pathToInvalidTsconfigFile,
+            tslintFilePath: pathToTslintFile,
+            options: { formatter: 'verbose' },
+          });
+        } catch (error) {
+          expect(error.message).toMatch('ERROR: (no-console)');
+        }
+      });
+    });  
   });
 
-  it('should reject for invalid files', async () => {
-    expect.assertions(1);
+  describe('tslintFilePath', () => {
+    const errorMessage = 'Could not find config file';
 
-    test = await setup();
-
-    await test.run(async ({ [taskPath]: tslint }) => {
-      try {
-        await tslint({
-          tsconfigFilePath: pathToInvalidTsconfigFile,
-          tslintFilePath: pathToTslintFile,
-        });
-      } catch (error) {
-        expect(error.message).toMatch('Calls to \'console.error\' are not allowed');
-      }
+    it('should reject if a tslint.json could not be found', async () => {
+      expect.assertions(1);
+  
+      test = await setup();
+  
+      await test.run(async ({ [taskPath]: tslint }) => {
+        try {
+          await tslint({
+            tsconfigFilePath: pathToValidTsconfigFile,
+            tslintFilePath: 'no-file',
+          });
+        } catch (error) {
+          expect(error.message).toMatch(errorMessage);
+        }
+      });
     });
+  
+    it('should reject if a tslint.json was not provided', async () => {
+      expect.assertions(1);
+  
+      test = await setup();
+  
+      await test.run(async ({ [taskPath]: tslint }) => {
+        try {
+          await tslint({
+            tsconfigFilePath: pathToValidTsconfigFile,
+          });
+        } catch (error) {
+          expect(error.message).toMatch(errorMessage);
+        }
+      });
+    });  
   });
-
-  it('should reject if a tslint.json could not be found', async () => {
-    expect.assertions(1);
-
-    test = await setup();
-
-    await test.run(async ({ [taskPath]: tslint }) => {
-      try {
-        await tslint({
-          tsconfigFilePath: pathToValidTsconfigFile,
-          tslintFilePath: 'no-file',
-        });
-      } catch (error) {
-        expect(error.message).toMatch('Could not find config file');
-      }
+  
+  describe('tsConfigFilePath', () => {
+    const errorMessage = 'The specified path does not exist';
+    
+    it('should reject if a tsconfig.json could not be found', async () => {
+      expect.assertions(1);
+  
+      test = await setup();
+  
+      await test.run(async ({ [taskPath]: tslint }) => {
+        try {
+          await tslint({
+            tsconfigFilePath: 'no-file',
+            tslintFilePath: pathToTslintFile,
+          });
+        } catch (error) {
+          expect(error.message).toMatch(errorMessage);
+        }
+      });
     });
-  });
-
-  it('should reject if a tslint.json was not provided', async () => {
-    expect.assertions(1);
-
-    test = await setup();
-
-    await test.run(async ({ [taskPath]: tslint }) => {
-      try {
-        await tslint({
-          tsconfigFilePath: pathToValidTsconfigFile,
-        });
-      } catch (error) {
-        expect(error.message).toMatch('Could not find config file');
-      }
-    });
-  });
-
-  it('should pass configuration to the linter', async () => {
-    expect.assertions(1);
-
-    test = await setup();
-
-    await test.run(async ({ [taskPath]: tslint }) => {
-      try {
-        await tslint({
-          tsconfigFilePath: pathToInvalidTsconfigFile,
-          tslintFilePath: pathToTslintFile,
-          options: { formatter: 'verbose' },
-        });
-      } catch (error) {
-        expect(error.message).toMatch('ERROR: (no-console)');
-      }
-    });
+  
+    it('should reject if a tsconfig.json was not provided', async () => {
+      expect.assertions(1);
+  
+      test = await setup();
+  
+      await test.run(async ({ [taskPath]: tslint }) => {
+        try {
+          await tslint({
+            tslintFilePath: pathToTslintFile,
+          });
+        } catch (error) {
+          expect(error.message).toContain(errorMessage);
+        }
+      });
+    });  
   });
 });


### PR DESCRIPTION
Hey,

This pr should resolve https://github.com/wix/haste/issues/149.
I would like to open a discussion here about my suggested implementation, so please let me know if you prefer changing something with it.

**Background**:
Yoshi takes his tslint rules from [tslint-config-wix](https://github.com/wix/tslint-config-wix), and it is really not enough.
In order to improve the rules, we need to merge this [pr](https://github.com/wix/tslint-config-wix/pull/9), and it will create a major version 2.0.0, so yoshi won't get it automatically, as this is a breaking change.

After this pr will get merged, it will require using type-checking, and this is exactly why I am creating this pr, to enable haste to support type-check for tslint.

Another pr will be required in yoshi as well, but first I want to make sure we all agree on the implementation details:

**Breaking changes**:
1. I would like to pass another parameter to the tslint task - `tsconfigFilePath` which will be the tsconfig file path. I don't expect any project to supply this path, only that yoshi will pass it to haste (yoshi assumes it will be in the root of the project).

2. Deprecate `pattern` parameter, because it is no longer needed once we pass the `tsconfig.json` file, which specifies the `include` and `exclude` files.

3. Rename `configurationFilePath` parameter to `tslintFilePath`. Since we now have 2 configuration files, it will be better imo to have `tslintFilePath` & `tsconfigFilePath` parameters.
I thought maybe even to simplify it by calling them `tslint` & `tsconfig`, but it might be less explicit, so I don't really mind what is it going to be.

**Small bug fixes**:
1. I found a small bug here: https://github.com/wix/haste/blob/master/packages/haste-task-tslint/src/index.js#L17. The default value should be empty string, not `null`. I added a test for it `should reject if a tslint.json was not provided` where I don't pass this argument. Before the fix, it will fail because it expects to get string.

**Backgward compatability**:
I guess that only yoshi supplies the deprecated `pattern` or `configurationFilePath` params, but if this is not the case, we should exit with a nice error message to inform the user about this deprecation. I am not sure we need to do that.