### PR TITLE
Support running haste-task-typescript on windows 

### DIFF
--- a/packages/haste-task-typescript/package.json
+++ b/packages/haste-task-typescript/package.json
@@ -9,6 +9,7 @@
   "license": "MIT",
   "dependencies": {
     "chalk": "^2.3.0",
+    "cross-spawn": "^6.0.5",
     "dargs": "^5.1.0"
   },
   "devDependencies": {

--- a/packages/haste-task-typescript/src/index.js
+++ b/packages/haste-task-typescript/src/index.js
@@ -1,5 +1,5 @@
 const dargs = require('dargs');
-const { spawn } = require('child_process');
+const spawn = require('cross-spawn');
 const { hasErrorMessage, hasCompletionMessage, colorPrint } = require('./utils');
 
 const defaultOptions = { project: './' };


### PR DESCRIPTION
Use `cross-spawn` to support running `tsc` on  windows