### PR TITLE
catch async errors that have been thrown outside of the main function call

### DIFF
--- a/packages/haste-core/test/fixtures/error-outside-async.js
+++ b/packages/haste-core/test/fixtures/error-outside-async.js
@@ -1,0 +1,5 @@
+setTimeout(() => {
+  Promise.reject(new Error('unsuccessful'));
+}, 1000);
+
+module.exports = () => new Promise(() => {});

--- a/packages/haste-core/test/haste.spec.js
+++ b/packages/haste-core/test/haste.spec.js
@@ -15,6 +15,7 @@ const requireErrorPath = resolveFromFixtures('require-error');
 const nonAsyncPath = resolveFromFixtures('non-async');
 const noErrorPath = resolveFromFixtures('no-error');
 const errorOutsidePath = resolveFromFixtures('error-outside');
+const errorOutsideAsyncPath = resolveFromFixtures('error-outside-async');
 const idlePath = resolveFromFixtures('idle');
 
 describe('haste', () => {
@@ -121,6 +122,20 @@ describe('haste', () => {
       try {
         await test.run(async ({ [errorOutsidePath]: errorOutside }) => {
           await errorOutside();
+        });
+      } catch (error) {
+        expect(error.message).toMatch('Error in worker');
+      }
+    });
+
+    it('should reject if a task threw an error outside if it\'s function invocation', async () => {
+      expect.assertions(1);
+
+      test = await setup();
+
+      try {
+        await test.run(async ({ [errorOutsideAsyncPath]: errorOutsideAsync }) => {
+          await errorOutsideAsync();
         });
       } catch (error) {
         expect(error.message).toMatch('Error in worker');

--- a/packages/haste-worker-farm/src/worker-bin.js
+++ b/packages/haste-worker-farm/src/worker-bin.js
@@ -6,6 +6,8 @@ let modulePath = null;
 
 process.on('uncaughtException', handleError);
 
+process.on('unhandledRejection', handleError);
+
 process.on('message', ({ type, options }) => {
   switch (type) {
     case 'CHILD_MESSAGE_INITIALIZE':


### PR DESCRIPTION
If an async error has been thrown outside if the main function call the worker will not get a message.