### PR TITLE
typescript-task: support typescript@2.9 watch mode

### DIFF
--- a/packages/haste-task-typescript/src/index.js
+++ b/packages/haste-task-typescript/src/index.js
@@ -1,6 +1,6 @@
 const dargs = require('dargs');
 const { spawn } = require('child_process');
-const { hasErrorMessage, hasCompletionMessage, colorPrint } = require('./utils');
+const { hasCompletionMessage, colorPrint } = require('./utils');
 
 const defaultOptions = { project: './' };
 
@@ -19,10 +19,8 @@ module.exports = async (options = {}) => {
 
       lines.forEach(colorPrint);
 
-      if (options.watch) {
-        if (hasCompletionMessage(lines) || hasErrorMessage(lines)) {
-          resolve();
-        }
+      if (options.watch && hasCompletionMessage(lines)) {
+        resolve();
       }
     });
 

--- a/packages/haste-task-typescript/src/utils.js
+++ b/packages/haste-task-typescript/src/utils.js
@@ -1,16 +1,14 @@
 const chalk = require('chalk');
 
-const typescriptCompletionRegex = /Compilation complete/;
+const typescriptCompletionRegex = /Watching for file changes/;
+const typescriptCompletionErrorRegex = /Found [1-9]+/;
 const typescriptErrorRegex = /error TS\d+:/;
 
 module.exports.hasCompletionMessage = lines =>
   lines.some(line => typescriptCompletionRegex.test(line));
 
-module.exports.hasErrorMessage = lines =>
-  lines.some(line => typescriptErrorRegex.test(line));
-
 module.exports.colorPrint = (line) => {
-  if (typescriptErrorRegex.test(line)) {
+  if (typescriptErrorRegex.test(line) || typescriptCompletionErrorRegex.test(line)) {
     return console.error(chalk.red(line));
   }
 

--- a/packages/haste-task-typescript/test/index.spec.js
+++ b/packages/haste-task-typescript/test/index.spec.js
@@ -75,7 +75,7 @@ describe('haste-task-typescript', () => {
         await typescript({ project: test.cwd, watch: true });
       });
 
-      expect(test.stdio.stdout).toMatch('Compilation complete. Watching for file changes.');
+      expect(test.stdio.stdout).toMatch('Found 0 errors. Watching for file changes.');
       expect(test.stdio.stdout).toMatch(greenColor);
       expect(test.files['dist/valid.js'].content).toEqual(transpiledFixture);
     });
@@ -91,6 +91,7 @@ describe('haste-task-typescript', () => {
       });
 
       expect(test.stdio.stderr).toMatch('error TS2304: Cannot find name');
+      expect(test.stdio.stderr).toMatch('Found 1 error. Watching for file changes.');
       expect(test.stdio.stderr).toMatch(redColor);
     });
   });


### PR DESCRIPTION
The watch mode completion message on TypeScript 2.9 has been changed, from "Compilation complete.  Watching for file changes." to "Found X error/s. Watching for file changes.", so I simply changed the regex to look for "Watching for file changes" (because it appears in all versions - 2.9 and below) and simplified the condition that resolves the promise.

In addition, in case there's an error (so "Found X errors" appears), I draw the whole completion line in red.