### PR TITLE
haste-task-sass: remove 'node-sass' from dependencies

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -12,6 +12,7 @@
     "class-methods-use-this": "off",
     "global-require": "off",
     "import/no-dynamic-require": "off",
+    "import/no-extraneous-dependencies": "off",
     "no-confusing-arrow": "off",
     "no-console": "off",
     "no-multi-assign": "off",

--- a/packages/haste-task-sass/package.json
+++ b/packages/haste-task-sass/package.json
@@ -7,10 +7,8 @@
     "node": ">=8"
   },
   "license": "MIT",
-  "dependencies": {
-    "node-sass": "^4.5.3"
-  },
   "devDependencies": {
-    "haste-test-utils": "^0.2.8"
+    "haste-test-utils": "^0.2.8",
+    "node-sass": "^4.5.3"
   }
 }

--- a/packages/haste-task-sass/src/index.js
+++ b/packages/haste-task-sass/src/index.js
@@ -10,7 +10,7 @@ module.exports = async ({ pattern, target, options }, { fs }) => {
   } catch (error) {
     if (error.code === 'MODULE_NOT_FOUND') {
       throw new Error(
-        '`haste-task-sass` requires `node-sass` >=4. Please install it and re-run.',
+        'Running this requires `node-sass` >=4. Please install it and re-run.',
       );
     }
     throw error;

--- a/packages/haste-task-sass/src/index.js
+++ b/packages/haste-task-sass/src/index.js
@@ -1,11 +1,23 @@
 const path = require('path');
-const sass = require('node-sass');
-
-const render = options => new Promise((resolve, reject) => {
-  sass.render(options, (err, result) => err ? reject(err) : resolve(result));
-});
 
 module.exports = async ({ pattern, target, options }, { fs }) => {
+  let sass;
+
+  try {
+    sass = require('node-sass');
+  } catch (error) {
+    if (error.code === 'MODULE_NOT_FOUND') {
+      throw new Error(
+        '`haste-task-sass` requires `node-sass` >=4. Please install it and re-run.',
+      );
+    }
+    throw error;
+  }
+
+  const render = opts => new Promise((resolve, reject) => {
+    sass.render(opts, (err, result) => err ? reject(err) : resolve(result));
+  });
+
   const files = await fs.read({ pattern });
 
   return Promise.all(

--- a/packages/haste-task-sass/src/index.js
+++ b/packages/haste-task-sass/src/index.js
@@ -2,9 +2,11 @@ const path = require('path');
 
 module.exports = async ({ pattern, target, options }, { fs }) => {
   let sass;
+  let sassVersion;
 
   try {
     sass = require('node-sass');
+    sassVersion = /^(\d+)/.exec(require('node-sass/package.json').version).pop();
   } catch (error) {
     if (error.code === 'MODULE_NOT_FOUND') {
       throw new Error(
@@ -12,6 +14,12 @@ module.exports = async ({ pattern, target, options }, { fs }) => {
       );
     }
     throw error;
+  }
+
+  if (Number(sassVersion) < 4) {
+    throw new Error(
+      `The installed version of \`node-sass\` is not compatible (expected: >= 4, actual: ${sassVersion}).`,
+    );
   }
 
   const render = opts => new Promise((resolve, reject) => {


### PR DESCRIPTION
This PR moves `node-sass` from dependencies and into `devDependencies`. Installing `node-sass` should be up to whoever uses this package.