### PR TITLE
haste-task-karma: remove karma from the dependencies

### DIFF
--- a/packages/haste-task-karma/README.md
+++ b/packages/haste-task-karma/README.md
@@ -1,6 +1,8 @@
 # haste-task-karma
 Haste task to run [Karma](https://github.com/karma-runner/karma)
 
+**NOTE:** This task requires karma to be install
+
 ## Options
 
 ### Config

--- a/packages/haste-task-karma/package.json
+++ b/packages/haste-task-karma/package.json
@@ -7,14 +7,12 @@
   "engines": {
     "node": ">=8"
   },
-  "dependencies": {
-    "karma": "^1.7.1"
-  },
   "devDependencies": {
     "haste-test-utils": "^0.2.8",
     "jasmine-core": "^2.8.0",
     "karma-jasmine": "^1.1.0",
     "karma-phantomjs-launcher": "^1.0.4",
-    "strip-ansi": "4.0.0"
+    "strip-ansi": "4.0.0",
+    "karma":"^2.0.3"
   }
 }

--- a/packages/haste-task-karma/src/index.js
+++ b/packages/haste-task-karma/src/index.js
@@ -1,7 +1,27 @@
-const { Server } = require('karma');
-
 module.exports = async (config) => {
   return new Promise((resolve, reject) => {
+    let karmaVersion;
+    let Server;
+
+    try {
+      Server = require('karma').Server;
+      karmaVersion = /^(\d+)/.exec(require('karma/package.json').version).pop();
+    } catch (error) {
+      if (error.code === 'MODULE_NOT_FOUND') {
+        reject(new Error(
+          'Running this requires `karma` >=1. Please install it and re-run.',
+        ));
+      }
+
+      reject(error);
+    }
+
+    if (Number(karmaVersion) < 1) {
+      reject(new Error(
+        `The installed version of \`karma\` is not compatible (expected: >= 1, actual: ${karmaVersion}).`,
+      ));
+    }
+
     const server = new Server(config, (exitCode) => {
       if (exitCode === 0) {
         resolve();


### PR DESCRIPTION
Remove karma from the dependencies of `haste-task-karma`, so it would be the user's decision whether to install it or not.