### PR TITLE
Move less to dev dependencies and throw an error if it's missing

### DIFF
--- a/packages/haste-task-less/package.json
+++ b/packages/haste-task-less/package.json
@@ -7,10 +7,8 @@
     "node": ">=8"
   },
   "license": "MIT",
-  "dependencies": {
-    "less": "^2.7.2"
-  },
   "devDependencies": {
-    "haste-test-utils": "^0.3.0"
+    "haste-test-utils": "^0.3.0",
+    "less": "^2.7.2"
   }
 }

--- a/packages/haste-task-less/src/index.js
+++ b/packages/haste-task-less/src/index.js
@@ -1,10 +1,29 @@
-const less = require('less');
-
-const render = (content, options) => new Promise((resolve, reject) => {
-  less.render(content, options, (err, result) => err ? reject(err) : resolve(result));
-});
-
 module.exports = async ({ pattern, target, options }, { fs }) => {
+  let less;
+  let lessVersion;
+
+  try {
+    less = require('less');
+    lessVersion = /^(\d+)/.exec(require('less/package.json').version).pop();
+  } catch (error) {
+    if (error.code === 'MODULE_NOT_FOUND') {
+      throw new Error(
+        'Running this requires `less` >=2.7.2. Please install it and re-run.',
+      );
+    }
+    throw error;
+  }
+
+  if (Number(lessVersion) < 4) {
+    throw new Error(
+      `The installed version of \`less\` is not compatible (expected: >= 2.7.2, actual: ${lessVersion}).`,
+    );
+  }
+
+  const render = (content, opts) => new Promise((resolve, reject) => {
+    less.render(content, opts, (err, result) => err ? reject(err) : resolve(result));
+  });
+
   const files = await fs.read({ pattern });
 
   return Promise.all(

--- a/packages/haste-task-less/src/index.js
+++ b/packages/haste-task-less/src/index.js
@@ -8,15 +8,15 @@ module.exports = async ({ pattern, target, options }, { fs }) => {
   } catch (error) {
     if (error.code === 'MODULE_NOT_FOUND') {
       throw new Error(
-        'Running this requires `less` >=2.7.2. Please install it and re-run.',
+        'Running this requires `less` >=2. Please install it and re-run.',
       );
     }
     throw error;
   }
 
-  if (Number(lessVersion) < 4) {
+  if (Number(lessVersion) < 2) {
     throw new Error(
-      `The installed version of \`less\` is not compatible (expected: >= 2.7.2, actual: ${lessVersion}).`,
+      `The installed version of \`less\` is not compatible (expected: >= 2, actual: ${lessVersion}).`,
     );
   }
 


### PR DESCRIPTION
This PR moves less to be a dev dependency and throws an error if it's missing or in the wrong version.