### PR TITLE
haste-service-fs: read to ignore node_modules dir

### DIFF
--- a/packages/haste-service-fs/src/read.js
+++ b/packages/haste-service-fs/src/read.js
@@ -7,7 +7,7 @@ module.exports = async ({ pattern, source, cwd = process.cwd(), options } = {}) 
     cwd = path.isAbsolute(source) ? source : path.join(cwd, source);
   }
 
-  const defaultOptions = { nodir: true };
+  const defaultOptions = { onlyFiles: true, ignore: ['**/node_modules'] };
 
   const files = await globby(pattern, {
     ...defaultOptions,


### PR DESCRIPTION
In addition, `onlyFiles` -> `nodir` as `globby` moved from `node-glob` to `fast-glob`.

@ronami please.