### PR TITLE
Add maxConcurrentCalls option to Runner

### DIFF
--- a/packages/haste-core/src/create-runner.js
+++ b/packages/haste-core/src/create-runner.js
@@ -1,8 +1,8 @@
 const Runner = require('./runner');
 const Logger = require('haste-plugin-logger');
 
-module.exports = ({ plugins = [], logger = new Logger() } = {}) => {
-  const runner = new Runner();
+module.exports = ({ plugins = [], logger = new Logger(), maxConcurrentCalls } = {}) => {
+  const runner = new Runner({ maxConcurrentCalls });
 
   [...plugins, logger].forEach(plugin => plugin.apply(runner));
 

--- a/packages/haste-core/src/runner.js
+++ b/packages/haste-core/src/runner.js
@@ -5,8 +5,8 @@ const { Farm } = require('haste-worker-farm');
 const Execution = require('./execution');
 
 module.exports = class Runner {
-  constructor() {
-    this.farm = new Farm({ maxConcurrentCalls: os.cpus().length });
+  constructor({ maxConcurrentCalls = os.cpus().length }) {
+    this.farm = new Farm({ maxConcurrentCalls });
     this.executions = [];
 
     this.hooks = {


### PR DESCRIPTION
Hello!

I'm working on fixing a bug with running `app-server` task in a few processes from `start` command of `yoshi`.
For that I need to have ability to pass `maxConcurrentCalls` to Runner constructor. 
It's a minor change but still a blocker for me.

Thanks!